### PR TITLE
Add iterators of the parsed document structure

### DIFF
--- a/examples/autoschema.rs
+++ b/examples/autoschema.rs
@@ -1,0 +1,158 @@
+/// Work-in-Progress.  This program is not done yet.
+///
+/// The `autoschema` program scans over a corpus of input documents and emits
+/// a description of the kinds of nodes seen at each DocPath in the document.
+/// This information can then be used to auto-generate a schema for the input
+/// documents.
+///
+/// IOW, this program helps you do what you should have done when you thought
+/// "Who cares? Its just JSON! It's schema free!".
+use ansi_term::{Color, Style};
+use anyhow::Result;
+use clap::Parser;
+use serde_annotate::{DocPath, Document, Int};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[derive(Default)]
+struct ColorProfile {
+    error: Style,
+    ok: Style,
+}
+
+impl ColorProfile {
+    pub fn basic() -> Self {
+        ColorProfile {
+            error: Style::new().fg(Color::Red),
+            ok: Style::new().fg(Color::Green),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Schema {
+    null: u32,
+    boolean: u32,
+    string: u32,
+    integer: u32,
+    float: u32,
+    object: u32,
+    array: u32,
+    total: u32,
+    children: HashMap<String, Schema>,
+}
+
+impl Schema {
+    fn get_mut(&mut self, path: &[DocPath]) -> &mut Self {
+        let mut ret = self;
+        let n = path.len() - 1;
+        for (i, p) in path.iter().enumerate() {
+            let (key, obj, arr) = match p {
+                DocPath::Name(x) => (*x, 1, 0),
+                DocPath::Index(_) => ("[_]", 0, 1),
+            };
+            if i <= n {
+                ret.total += 1;
+                ret.object += obj;
+                ret.array += arr;
+            }
+            ret = ret.children.entry(key.to_string()).or_default();
+        }
+        ret
+    }
+
+    fn check_str(&mut self, s: &str) {
+        if let Ok(_) = Int::from_str_radix(s, 0) {
+            self.integer += 1;
+        } else {
+            match s {
+                "true" | "True" | "TRUE" => self.boolean += 1,
+                "false" | "False" | "FALSE" => self.boolean += 1,
+                _ => self.string += 1,
+            }
+        }
+    }
+
+    fn detect(&mut self, root: &Document) {
+        for (path, doc) in root.iter_path() {
+            let mut node = self.get_mut(&path);
+            node.total += 1;
+            match doc {
+                Document::Null => node.null += 1,
+                Document::Boolean(_) => node.boolean += 1,
+                Document::String(s, _) => node.check_str(s.as_str()),
+                Document::StaticStr(s, _) => node.check_str(s),
+                Document::Int(_) => node.integer += 1,
+                Document::Float(_) => node.float += 1,
+                _ => {
+                    panic!("Unexpected node {:?}", node);
+                }
+            }
+        }
+    }
+
+    fn print(&self, name: &str, indent: usize, color: &ColorProfile) {
+        let good = self.total == self.null
+            || self.total == self.boolean
+            || self.total == self.string
+            || self.total == self.integer
+            || self.total == self.float
+            || self.total == self.object
+            || self.total == self.array;
+
+        print!(
+            "{}",
+            (if good {
+                color.ok.prefix()
+            } else {
+                color.error.prefix()
+            })
+            .to_string()
+        );
+        print!("{0:>1$}|{2:->20}: ", "", indent * 4, name,);
+        print!(
+            "(n:{:<3} b:{:<3} s:{:<3} i:{:<3} f:{:<3} o:{:<3} a:{:<3}) / {:<3}",
+            self.null,
+            self.boolean,
+            self.string,
+            self.integer,
+            self.float,
+            self.object,
+            self.array,
+            self.total,
+        );
+        println!("{}", color.ok.suffix().to_string());
+        for (k, v) in self.children.iter() {
+            v.print(k.as_str(), indent + 1, color)
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(name = "FILES")]
+    files: Vec<PathBuf>,
+
+    #[clap(short, long, value_parser)]
+    color: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let color = if args.color {
+        ColorProfile::basic()
+    } else {
+        ColorProfile::default()
+    };
+
+    let mut schema = Schema::default();
+    for f in args.files {
+        println!("Checking {:?}", f);
+        let text = std::fs::read_to_string(f)?;
+        let document = Document::parse(&text)?;
+        schema.detect(&document);
+    }
+    schema.print("", 0, &color);
+    Ok(())
+}

--- a/src/doc_iter.rs
+++ b/src/doc_iter.rs
@@ -1,0 +1,295 @@
+use crate::document::Document;
+
+impl Document {
+    /// Returns an iterator over all all document nodes including
+    /// comments and fragments.
+    ///
+    /// When encountering a container node (mapping, sequence or fragment),
+    /// the container node is yielded first, then all of its children.
+    pub fn iter(&self) -> DocIter {
+        let v = std::slice::from_ref(self);
+        DocIter {
+            stack: vec![v.iter()],
+        }
+    }
+
+    /// Returns an iterator over all value nodes in the document.
+    /// The iterator yields tuples of (object-path, value-node).
+    pub fn iter_path(&self) -> DocPathIter {
+        let v = std::slice::from_ref(self);
+        DocPathIter {
+            stack: vec![v.iter()],
+            aggregate: Vec::new(),
+            path: Vec::new(),
+        }
+    }
+
+    /// Returns a mutable iterator over all value nodes in the document.
+    /// The iterator yields tuples of (object-path, value-node).
+    pub fn iter_path_mut(&mut self) -> DocPathIterMut {
+        let v = std::slice::from_mut(self);
+        DocPathIterMut {
+            stack: vec![v.iter_mut()],
+            aggregate: Vec::new(),
+            path: Vec::new(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Document {
+    type Item = &'a Document;
+    type IntoIter = DocIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub struct DocIter<'a> {
+    stack: Vec<std::slice::Iter<'a, Document>>,
+}
+
+impl<'a> Iterator for DocIter<'a> {
+    type Item = &'a Document;
+    fn next(&mut self) -> Option<Self::Item> {
+        let val = loop {
+            let top = match self.stack.last_mut() {
+                Some(top) => top,
+                None => return None,
+            };
+            if let Some(val) = top.next() {
+                break val;
+            }
+            self.stack.pop();
+        };
+        match val {
+            Document::Mapping(v) => self.stack.push(v.iter()),
+            Document::Sequence(v) => self.stack.push(v.iter()),
+            Document::Compact(v) => self.stack.push(std::slice::from_ref(&**v).iter()),
+            Document::Fragment(v) => self.stack.push(v.iter()),
+            _ => {}
+        };
+        Some(val)
+    }
+}
+
+pub struct DocPathIter<'a> {
+    stack: Vec<std::slice::Iter<'a, Document>>,
+    aggregate: Vec<bool>,
+    path: Vec<DocPath<'a>>,
+}
+
+pub struct DocPathIterMut<'a> {
+    stack: Vec<std::slice::IterMut<'a, Document>>,
+    aggregate: Vec<bool>,
+    path: Vec<DocPath<'a>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum DocPath<'a> {
+    Name(&'a str),
+    Index(usize),
+}
+
+impl std::fmt::Display for DocPath<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DocPath::Name(n) => write!(f, "{}", n),
+            DocPath::Index(i) => write!(f, "{}", i),
+        }
+    }
+}
+
+impl<'a> Iterator for DocPathIter<'a> {
+    type Item = (Vec<DocPath<'a>>, &'a Document);
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(top) = self.stack.last_mut() {
+            let val = top.next();
+            match val {
+                Some(Document::Comment(_, _)) => {}
+                Some(Document::Mapping(v)) => {
+                    self.stack.push(v.iter());
+                    self.path.push(DocPath::Name(""));
+                    self.aggregate.push(true);
+                }
+                Some(Document::Sequence(v)) => {
+                    self.stack.push(v.iter());
+                    self.path.push(DocPath::Index(usize::MAX));
+                    self.aggregate.push(true);
+                }
+                Some(Document::Compact(v)) => {
+                    self.stack.push(std::slice::from_ref(&**v).iter());
+                    self.aggregate.push(false);
+                }
+                Some(Document::Fragment(f)) => {
+                    match self.path.last_mut() {
+                        Some(DocPath::Name(ref mut n)) => match val.unwrap().as_kv() {
+                            Ok((k, v)) => {
+                                *n = k.as_str().expect("DocPath key");
+                                self.stack.push(std::slice::from_ref(v).iter());
+                            }
+                            Err(_) => continue,
+                        },
+                        Some(DocPath::Index(_)) => match val.unwrap().as_value() {
+                            Ok(v) => self.stack.push(std::slice::from_ref(v).iter()),
+                            Err(_) => continue,
+                        },
+                        _ => {
+                            self.stack.push(f.iter());
+                        }
+                    };
+                    self.aggregate.push(false);
+                }
+                Some(_) => {
+                    if let Some(DocPath::Index(ref mut i)) = self.path.last_mut() {
+                        *i = i.wrapping_add(1);
+                    }
+                    return Some((self.path.clone(), val.unwrap()));
+                }
+                None => {
+                    self.stack.pop();
+                    if self.aggregate.pop() == Some(true) {
+                        self.path.pop();
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+impl<'a> Iterator for DocPathIterMut<'a> {
+    type Item = (Vec<DocPath<'a>>, &'a mut Document);
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(top) = self.stack.last_mut() {
+            let val = top.next();
+            match val {
+                Some(Document::Comment(_, _)) => {}
+                Some(Document::Mapping(v)) => {
+                    self.stack.push(v.iter_mut());
+                    self.path.push(DocPath::Name(""));
+                    self.aggregate.push(true);
+                }
+                Some(Document::Sequence(v)) => {
+                    self.stack.push(v.iter_mut());
+                    self.path.push(DocPath::Index(usize::MAX));
+                    self.aggregate.push(true);
+                }
+                Some(Document::Compact(ref mut v)) => {
+                    self.stack.push(std::slice::from_mut(&mut **v).iter_mut());
+                    self.aggregate.push(false);
+                }
+                Some(Document::Fragment(_)) => {
+                    let val = val.unwrap();
+                    match self.path.last_mut() {
+                        Some(DocPath::Name(ref mut n)) => match val.as_kv_mut() {
+                            Ok((k, v)) => {
+                                *n = k.as_str().expect("DocPath key");
+                                self.stack.push(std::slice::from_mut(v).iter_mut());
+                            }
+                            Err(_) => continue,
+                        },
+                        Some(DocPath::Index(_)) => match val.as_value_mut() {
+                            Ok(v) => self.stack.push(std::slice::from_mut(v).iter_mut()),
+                            Err(_) => continue,
+                        },
+                        _ => {
+                            // Unwrap is ok: we've already matched Document::Fragment.
+                            self.stack.push(val.fragments_mut().unwrap().iter_mut());
+                        }
+                    };
+                    self.aggregate.push(false);
+                }
+                Some(_) => {
+                    if let Some(DocPath::Index(ref mut i)) = self.path.last_mut() {
+                        *i = i.wrapping_add(1);
+                    }
+                    return Some((self.path.clone(), val.unwrap()));
+                }
+                None => {
+                    self.stack.pop();
+                    if self.aggregate.pop() == Some(true) {
+                        self.path.pop();
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct SampleInner {
+        k: u32,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct Sample {
+        a: u32,
+        b: u32,
+        c: SampleInner,
+        d: Vec<u32>,
+    }
+
+    const SAMPLE: &str = r#"
+    {
+        a: 1,
+        b: 2,
+        c: {
+            k: 0,
+        },
+        d: [
+            100,
+            200,
+        ]
+    }"#;
+
+    #[test]
+    fn test_iter_path() -> Result<()> {
+        let doc = Document::parse(SAMPLE)?;
+        let items = doc
+            .iter_path()
+            .map(|(p, d)| {
+                let path = p
+                    .iter()
+                    .map(DocPath::to_string)
+                    .collect::<Vec<_>>()
+                    .join(".");
+                (path, d.try_into().unwrap())
+            })
+            .collect::<Vec<(String, u32)>>();
+        assert_eq!(items[0], ("a".into(), 1));
+        assert_eq!(items[1], ("b".into(), 2));
+        assert_eq!(items[2], ("c.k".into(), 0));
+        assert_eq!(items[3], ("d.0".into(), 100));
+        assert_eq!(items[4], ("d.1".into(), 200));
+        Ok(())
+    }
+
+    #[test]
+    fn test_iter_path_mut() -> Result<()> {
+        let expect = Sample {
+            a: 1,
+            b: 2,
+            c: SampleInner { k: 99 },
+            d: vec![100, 200],
+        };
+
+        // The sample text has "k: 0".  We examine the object path
+        // and transform the value of that node into a 99.
+        let sample = crate::Deserialize::try_from(SAMPLE)?
+            .transform(|_, path_str, _doc| match path_str {
+                "c.k" => Some(Document::Int(99u8.into())),
+                _ => None,
+            })
+            .into::<Sample>()?;
+        assert_eq!(sample, expect);
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use serde::{de, ser};
 use std::char::CharTryFromError;
 use std::fmt::Display;
 use std::num::ParseIntError;
+use std::str::ParseBoolError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -23,6 +24,8 @@ pub enum Error {
     KeyTypeError(&'static str),
     #[error(transparent)]
     ParseError(#[from] ParseError),
+    #[error(transparent)]
+    ParseBoolError(#[from] ParseBoolError),
     #[error(transparent)]
     ParseIntError(#[from] ParseIntError),
     #[error(transparent)]

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -280,16 +280,28 @@ macro_rules! impl_from_int {
     };
 }
 
-impl_from_int!(u8);
-impl_from_int!(u16);
-impl_from_int!(u32);
-impl_from_int!(u64);
-impl_from_int!(u128);
-impl_from_int!(i8);
-impl_from_int!(i16);
-impl_from_int!(i32);
-impl_from_int!(i64);
-impl_from_int!(i128);
+macro_rules! impl_to_from_int {
+    ($t:ty) => {
+        impl_from_int!($t);
+
+        impl From<$t> for Int {
+            fn from(val: $t) -> Self {
+                Int::new(val, Base::Dec)
+            }
+        }
+    };
+}
+
+impl_to_from_int!(u8);
+impl_to_from_int!(u16);
+impl_to_from_int!(u32);
+impl_to_from_int!(u64);
+impl_to_from_int!(u128);
+impl_to_from_int!(i8);
+impl_to_from_int!(i16);
+impl_to_from_int!(i32);
+impl_to_from_int!(i64);
+impl_to_from_int!(i128);
 impl_from_int!(f32);
 impl_from_int!(f64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod annotate;
 mod color;
 mod de;
+mod doc_iter;
 mod document;
 mod error;
 mod hexdump;
@@ -11,8 +12,10 @@ mod ser;
 mod yaml;
 
 pub use color::ColorProfile;
-pub use de::{from_str, Deserializer};
+pub use de::{from_str, Deserialize, Deserializer};
+pub use doc_iter::DocPath;
 pub use document::Document;
+pub use integer::{Int, IntValue};
 pub use json::Json;
 pub use ser::{serialize, AnnotatedSerializer};
 pub use yaml::Yaml;


### PR DESCRIPTION
1.  Add iterators over the document structure.  The iterators allow for examination and modification of documents before deserialization.  The planned use cases for this feature are:
    - To detect magic values like `"<random>"` in OpenTitan's hjson files and perform replacements with the intended randomized integers.
    - To examine a corpus of input documents and automatically suggest an appropriate schema for that corpus.  This will allow us to check conformance of hjsons to their corresponding schemas, thus reducing errors.

Signed-off-by: Chris Frantz <cfrantz@google.com>