### PR TITLE
Format 'hexstr' as a standard string

### DIFF
--- a/src/hexdump.rs
+++ b/src/hexdump.rs
@@ -1,7 +1,7 @@
-use std::fmt::Write;
 use crate::document::BytesFormat;
 use crate::error::Error;
 use regex::RegexBuilder;
+use std::fmt::Write;
 
 const HEX: &[u8; 16] = b"0123456789abcdef";
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -165,7 +165,14 @@ impl<'s, 'a> ser::Serializer for &'s mut AnnotatedSerializer<'a> {
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
         if let Some(string) = hexdump::to_string(v, self.bytesformat) {
-            Ok(Document::String(string, StrFormat::Multiline))
+            Ok(Document::String(
+                string,
+                if self.bytesformat == BytesFormat::HexStr {
+                    StrFormat::Standard
+                } else {
+                    StrFormat::Multiline
+                },
+            ))
         } else {
             Ok(Document::Bytes(v.to_vec()))
         }

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -378,8 +378,7 @@ fn test_bytes() -> Result<()> {
           0x65,0x20,0x6C,0x61,0x6D,0x62,
           ]
           # Encoded as `hexstr`
-          second_stanza: |-
-            69747320666c656563652077617320776869746520617320736e6f77
+          second_stanza: 69747320666c656563652077617320776869746520617320736e6f77
           # Encoded as `hexdump`
           third_stanza: |-
             00000000  45 76 65 72 79 77 68 65  72 65 20 74 68 61 74 20  |Everywhere that |
@@ -468,10 +467,7 @@ fn test_bytes() -> Result<()> {
             98
           ],
           # Encoded as `hexstr`
-          second_stanza: 
-            '''
-            69747320666c656563652077617320776869746520617320736e6f77
-            ''',
+          second_stanza: "69747320666c656563652077617320776869746520617320736e6f77",
           # Encoded as `hexdump`
           third_stanza: 
             '''


### PR DESCRIPTION
Hexstr is not a multiline string, so it should be formatted as a standard quoted string rather than a multiline block.

Signed-off-by: Chris Frantz <cfrantz@google.com>