### PR TITLE
Add bazel support to serde-annotate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 *.bak
 .*.swp
 private/
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,55 @@
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache 2 license
+])
+
+rust_library(
+    name = "serde_annotate",
+    srcs = glob(["**/*.rs"]),
+    compile_data = ["src/relax.pest"],
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2021",
+    proc_macro_deps = [
+        "//annotate_derive",
+        "//third_party/rust/crates:pest_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "crate-name=serde_annotate",
+    ],
+    version = "0.1.0",
+    deps = [
+        "//third_party/rust/crates:ansi_term",
+        "//third_party/rust/crates:inventory",
+        "//third_party/rust/crates:num_traits",
+        "//third_party/rust/crates:once_cell",
+        "//third_party/rust/crates:pest",
+        "//third_party/rust/crates:regex",
+        "//third_party/rust/crates:serde",
+        "//third_party/rust/crates:thiserror",
+    ],
+)
+
+rust_test(
+    name = "serde_annotate_test",
+    crate = ":serde_annotate",
+    deps = [
+        "//third_party/rust/crates:anyhow",
+    ],
+)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,28 @@ deser-hjson = "1.0.2"
 serde_bytes = "0.11"
 serde_yaml = "0.8.24"
 clap = { version="3.2.8", features=["derive"] }
+
+[workspace]
+members = [
+    ".",
+    "annotate_derive",
+]
+
+[workspace.metadata.raze]
+workspace_path = "//third_party/rust/crates"
+experimental_api = true
+package_aliases_dir = "third_party/rust/crates"
+genmode = "Remote"
+
+targets = [
+    "x86_64-unknown-linux-gnu",
+]
+
+[package.metadata.raze.crates.json5.'*']
+compile_data_attr = '[ "src/json5.pest" ]'
+
+[package.metadata.raze.crates.clap.'*']
+compile_data_attr = 'glob([ "*.md", "**/*.md" ])'
+
+[package.metadata.raze.crates.clap_derive.'*']
+compile_data_attr = 'glob([ "*.md", "**/*.md" ])'

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,8 @@
+workspace(name = "lowrisc_serde_annotate")
+
+# Rust Toolchain + crates.io Dependencies
+load("//third_party/rust:repos.bzl", "rust_repos")
+rust_repos()
+
+load("//third_party/rust:deps.bzl", "rust_deps")
+rust_deps()

--- a/annotate_derive/BUILD.bazel
+++ b/annotate_derive/BUILD.bazel
@@ -1,0 +1,38 @@
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache 2 license
+])
+
+rust_proc_macro(
+    name = "annotate_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "crate-name=annotate_derive",
+    ],
+    version = "0.1.0",
+    deps = [
+        "//third_party/rust/crates:proc_macro2",
+        "//third_party/rust/crates:proc_macro_error",
+        "//third_party/rust/crates:quote",
+        "//third_party/rust/crates:syn",
+    ],
+)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,0 +1,52 @@
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache 2 license
+])
+
+rust_binary(
+    name = "autoschema",
+    srcs = ["autoschema.rs"],
+    edition = "2021",
+    deps = [
+        "//:serde_annotate",
+        "//third_party/rust/crates:ansi_term",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:clap",
+    ],
+)
+
+rust_binary(
+    name = "samples",
+    srcs = ["samples.rs"],
+    edition = "2021",
+    deps = [
+        "//:serde_annotate",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:clap",
+        "//third_party/rust/crates:inventory",
+        "//third_party/rust/crates:serde",
+        "//third_party/rust/crates:serde_bytes",
+    ],
+)
+
+rust_binary(
+    name = "transcode",
+    srcs = ["transcode.rs"],
+    edition = "2021",
+    deps = [
+        "//:serde_annotate",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:clap",
+    ],
+)

--- a/examples/samples.rs
+++ b/examples/samples.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use clap::{ArgEnum, Parser};
 use serde_annotate::annotate::Annotate;
 use serde_annotate::{serialize, ColorProfile};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Annotate, Debug, PartialEq)]
 struct Coordinate {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,0 +1,32 @@
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache 2 license
+])
+
+rust_test(
+    name = "test_format",
+    srcs = ["test_format.rs"],
+    edition = "2021",
+    deps = [
+        "//:serde_annotate",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:deser_hjson",
+        "//third_party/rust/crates:inventory",
+        "//third_party/rust/crates:json5",
+        "//third_party/rust/crates:serde",
+        "//third_party/rust/crates:serde_bytes",
+        "//third_party/rust/crates:serde_json",
+        "//third_party/rust/crates:serde_yaml",
+    ],
+)

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde_annotate::annotate::Annotate;
 use serde_annotate::serialize;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 fn fixdoc(doc: &str) -> String {
     let mut s = String::new();

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -1,0 +1,220 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+licenses([
+    "notice",  # See individual crates for specific licenses
+])
+
+# Aliased targets
+alias(
+    name = "ansi_term",
+    actual = "@raze__ansi_term__0_12_1//:ansi_term",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "anyhow",
+    actual = "@raze__anyhow__1_0_65//:anyhow",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "clap",
+    actual = "@raze__clap__3_2_22//:clap",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "deser_hjson",
+    actual = "@raze__deser_hjson__1_0_2//:deser_hjson",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "inventory",
+    actual = "@raze__inventory__0_2_3//:inventory",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "json5",
+    actual = "@raze__json5__0_4_1//:json5",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "num_traits",
+    actual = "@raze__num_traits__0_2_15//:num_traits",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "once_cell",
+    actual = "@raze__once_cell__1_14_0//:once_cell",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "pest",
+    actual = "@raze__pest__2_3_1//:pest",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "pest_derive",
+    actual = "@raze__pest_derive__2_3_1//:pest_derive",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "proc_macro2",
+    actual = "@raze__proc_macro2__1_0_43//:proc_macro2",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "proc_macro_error",
+    actual = "@raze__proc_macro_error__1_0_4//:proc_macro_error",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "quote",
+    actual = "@raze__quote__1_0_21//:quote",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "regex",
+    actual = "@raze__regex__1_6_0//:regex",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde",
+    actual = "@raze__serde__1_0_144//:serde",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde_bytes",
+    actual = "@raze__serde_bytes__0_11_7//:serde_bytes",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde_derive",
+    actual = "@raze__serde_derive__1_0_144//:serde_derive",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde_json",
+    actual = "@raze__serde_json__1_0_85//:serde_json",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde_yaml",
+    actual = "@raze__serde_yaml__0_8_26//:serde_yaml",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "syn",
+    actual = "@raze__syn__1_0_100//:syn",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "thiserror",
+    actual = "@raze__thiserror__1_0_35//:thiserror",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/rust/crates/crates.bzl
+++ b/third_party/rust/crates/crates.bzl
@@ -1,0 +1,828 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")  # buildifier: disable=load
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")  # buildifier: disable=load
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: disable=load
+
+# EXPERIMENTAL -- MAY CHANGE AT ANY TIME: A mapping of package names to a set of normal dependencies for the Rust targets of that package.
+_DEPENDENCIES = {
+    "": {
+        "ansi_term": "@raze__ansi_term__0_12_1//:ansi_term",
+        "inventory": "@raze__inventory__0_2_3//:inventory",
+        "num-traits": "@raze__num_traits__0_2_15//:num_traits",
+        "once_cell": "@raze__once_cell__1_14_0//:once_cell",
+        "pest": "@raze__pest__2_3_1//:pest",
+        "regex": "@raze__regex__1_6_0//:regex",
+        "serde": "@raze__serde__1_0_144//:serde",
+        "thiserror": "@raze__thiserror__1_0_35//:thiserror",
+    },
+    "annotate_derive": {
+        "proc-macro-error": "@raze__proc_macro_error__1_0_4//:proc_macro_error",
+        "proc-macro2": "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "quote": "@raze__quote__1_0_21//:quote",
+        "syn": "@raze__syn__1_0_100//:syn",
+    },
+}
+
+# EXPERIMENTAL -- MAY CHANGE AT ANY TIME: A mapping of package names to a set of proc_macro dependencies for the Rust targets of that package.
+_PROC_MACRO_DEPENDENCIES = {
+    "": {
+        "pest_derive": "@raze__pest_derive__2_3_1//:pest_derive",
+    },
+    "annotate_derive": {
+    },
+}
+
+# EXPERIMENTAL -- MAY CHANGE AT ANY TIME: A mapping of package names to a set of normal dev dependencies for the Rust targets of that package.
+_DEV_DEPENDENCIES = {
+    "": {
+        "anyhow": "@raze__anyhow__1_0_65//:anyhow",
+        "clap": "@raze__clap__3_2_22//:clap",
+        "deser-hjson": "@raze__deser_hjson__1_0_2//:deser_hjson",
+        "json5": "@raze__json5__0_4_1//:json5",
+        "serde_bytes": "@raze__serde_bytes__0_11_7//:serde_bytes",
+        "serde_json": "@raze__serde_json__1_0_85//:serde_json",
+        "serde_yaml": "@raze__serde_yaml__0_8_26//:serde_yaml",
+    },
+    "annotate_derive": {
+    },
+}
+
+# EXPERIMENTAL -- MAY CHANGE AT ANY TIME: A mapping of package names to a set of proc_macro dev dependencies for the Rust targets of that package.
+_DEV_PROC_MACRO_DEPENDENCIES = {
+    "": {
+        "serde_derive": "@raze__serde_derive__1_0_144//:serde_derive",
+    },
+    "annotate_derive": {
+    },
+}
+
+def crate_deps(deps, package_name = None):
+    """EXPERIMENTAL -- MAY CHANGE AT ANY TIME: Finds the fully qualified label of the requested crates for the package where this macro is called.
+
+    WARNING: This macro is part of an expeirmental API and is subject to change.
+
+    Args:
+        deps (list): The desired list of crate targets.
+        package_name (str, optional): The package name of the set of dependencies to look up.
+            Defaults to `native.package_name()`.
+    Returns:
+        list: A list of labels to cargo-raze generated targets (str)
+    """
+
+    if not package_name:
+        package_name = native.package_name()
+
+    # Join both sets of dependencies
+    dependencies = _flatten_dependency_maps([
+        _DEPENDENCIES,
+        _PROC_MACRO_DEPENDENCIES,
+        _DEV_DEPENDENCIES,
+        _DEV_PROC_MACRO_DEPENDENCIES,
+    ])
+
+    if not deps:
+        return []
+
+    missing_crates = []
+    crate_targets = []
+    for crate_target in deps:
+        if crate_target not in dependencies[package_name]:
+            missing_crates.append(crate_target)
+        else:
+            crate_targets.append(dependencies[package_name][crate_target])
+
+    if missing_crates:
+        fail("Could not find crates `{}` among dependencies of `{}`. Available dependencies were `{}`".format(
+            missing_crates,
+            package_name,
+            dependencies[package_name],
+        ))
+
+    return crate_targets
+
+def all_crate_deps(normal = False, normal_dev = False, proc_macro = False, proc_macro_dev = False, package_name = None):
+    """EXPERIMENTAL -- MAY CHANGE AT ANY TIME: Finds the fully qualified label of all requested direct crate dependencies \
+    for the package where this macro is called.
+
+    If no parameters are set, all normal dependencies are returned. Setting any one flag will
+    otherwise impact the contents of the returned list.
+
+    Args:
+        normal (bool, optional): If True, normal dependencies are included in the
+            output list. Defaults to False.
+        normal_dev (bool, optional): If True, normla dev dependencies will be
+            included in the output list. Defaults to False.
+        proc_macro (bool, optional): If True, proc_macro dependencies are included
+            in the output list. Defaults to False.
+        proc_macro_dev (bool, optional): If True, dev proc_macro dependencies are
+            included in the output list. Defaults to False.
+        package_name (str, optional): The package name of the set of dependencies to look up.
+            Defaults to `native.package_name()`.
+
+    Returns:
+        list: A list of labels to cargo-raze generated targets (str)
+    """
+
+    if not package_name:
+        package_name = native.package_name()
+
+    # Determine the relevant maps to use
+    all_dependency_maps = []
+    if normal:
+        all_dependency_maps.append(_DEPENDENCIES)
+    if normal_dev:
+        all_dependency_maps.append(_DEV_DEPENDENCIES)
+    if proc_macro:
+        all_dependency_maps.append(_PROC_MACRO_DEPENDENCIES)
+    if proc_macro_dev:
+        all_dependency_maps.append(_DEV_PROC_MACRO_DEPENDENCIES)
+
+    # Default to always using normal dependencies
+    if not all_dependency_maps:
+        all_dependency_maps.append(_DEPENDENCIES)
+
+    dependencies = _flatten_dependency_maps(all_dependency_maps)
+
+    if not dependencies:
+        return []
+
+    return dependencies[package_name].values()
+
+def _flatten_dependency_maps(all_dependency_maps):
+    """Flatten a list of dependency maps into one dictionary.
+
+    Dependency maps have the following structure:
+
+    ```python
+    DEPENDENCIES_MAP = {
+        # The first key in the map is a Bazel package
+        # name of the workspace this file is defined in.
+        "package_name": {
+
+            # An alias to a crate target.     # The label of the crate target the
+            # Aliases are only crate names.   # alias refers to.
+            "alias":                          "@full//:label",
+        }
+    }
+    ```
+
+    Args:
+        all_dependency_maps (list): A list of dicts as described above
+
+    Returns:
+        dict: A dictionary as described above
+    """
+    dependencies = {}
+
+    for dep_map in all_dependency_maps:
+        for pkg_name in dep_map:
+            if pkg_name not in dependencies:
+                # Add a non-frozen dict to the collection of dependencies
+                dependencies.setdefault(pkg_name, dict(dep_map[pkg_name].items()))
+                continue
+
+            duplicate_crate_aliases = [key for key in dependencies[pkg_name] if key in dep_map[pkg_name]]
+            if duplicate_crate_aliases:
+                fail("There should be no duplicate crate aliases: {}".format(duplicate_crate_aliases))
+
+            dependencies[pkg_name].update(dep_map[pkg_name])
+
+    return dependencies
+
+def raze_fetch_remote_crates():
+    """This function defines a collection of repos and should be called in a WORKSPACE file"""
+    maybe(
+        http_archive,
+        name = "raze__aho_corasick__0_7_19",
+        url = "https://crates.io/api/v1/crates/aho-corasick/0.7.19/download",
+        type = "tar.gz",
+        sha256 = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e",
+        strip_prefix = "aho-corasick-0.7.19",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.aho-corasick-0.7.19.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ansi_term__0_12_1",
+        url = "https://crates.io/api/v1/crates/ansi_term/0.12.1/download",
+        type = "tar.gz",
+        sha256 = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2",
+        strip_prefix = "ansi_term-0.12.1",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.ansi_term-0.12.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__anyhow__1_0_65",
+        url = "https://crates.io/api/v1/crates/anyhow/1.0.65/download",
+        type = "tar.gz",
+        sha256 = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602",
+        strip_prefix = "anyhow-1.0.65",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.anyhow-1.0.65.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__atty__0_2_14",
+        url = "https://crates.io/api/v1/crates/atty/0.2.14/download",
+        type = "tar.gz",
+        sha256 = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
+        strip_prefix = "atty-0.2.14",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.atty-0.2.14.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__autocfg__1_1_0",
+        url = "https://crates.io/api/v1/crates/autocfg/1.1.0/download",
+        type = "tar.gz",
+        sha256 = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+        strip_prefix = "autocfg-1.1.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.autocfg-1.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__bitflags__1_3_2",
+        url = "https://crates.io/api/v1/crates/bitflags/1.3.2/download",
+        type = "tar.gz",
+        sha256 = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+        strip_prefix = "bitflags-1.3.2",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.bitflags-1.3.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__block_buffer__0_10_3",
+        url = "https://crates.io/api/v1/crates/block-buffer/0.10.3/download",
+        type = "tar.gz",
+        sha256 = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e",
+        strip_prefix = "block-buffer-0.10.3",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.block-buffer-0.10.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__cfg_if__1_0_0",
+        url = "https://crates.io/api/v1/crates/cfg-if/1.0.0/download",
+        type = "tar.gz",
+        sha256 = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        strip_prefix = "cfg-if-1.0.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.cfg-if-1.0.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__clap__3_2_22",
+        url = "https://crates.io/api/v1/crates/clap/3.2.22/download",
+        type = "tar.gz",
+        sha256 = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750",
+        strip_prefix = "clap-3.2.22",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.clap-3.2.22.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__clap_derive__3_2_18",
+        url = "https://crates.io/api/v1/crates/clap_derive/3.2.18/download",
+        type = "tar.gz",
+        sha256 = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65",
+        strip_prefix = "clap_derive-3.2.18",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.clap_derive-3.2.18.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__clap_lex__0_2_4",
+        url = "https://crates.io/api/v1/crates/clap_lex/0.2.4/download",
+        type = "tar.gz",
+        sha256 = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5",
+        strip_prefix = "clap_lex-0.2.4",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.clap_lex-0.2.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__cpufeatures__0_2_5",
+        url = "https://crates.io/api/v1/crates/cpufeatures/0.2.5/download",
+        type = "tar.gz",
+        sha256 = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320",
+        strip_prefix = "cpufeatures-0.2.5",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.cpufeatures-0.2.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__crypto_common__0_1_6",
+        url = "https://crates.io/api/v1/crates/crypto-common/0.1.6/download",
+        type = "tar.gz",
+        sha256 = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3",
+        strip_prefix = "crypto-common-0.1.6",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.crypto-common-0.1.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ctor__0_1_23",
+        url = "https://crates.io/api/v1/crates/ctor/0.1.23/download",
+        type = "tar.gz",
+        sha256 = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb",
+        strip_prefix = "ctor-0.1.23",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.ctor-0.1.23.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__deser_hjson__1_0_2",
+        url = "https://crates.io/api/v1/crates/deser-hjson/1.0.2/download",
+        type = "tar.gz",
+        sha256 = "1f486ff51f3ecdf9364736375a4b358b6eb9f02555d5324fa4837c00b5aa23f5",
+        strip_prefix = "deser-hjson-1.0.2",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.deser-hjson-1.0.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__digest__0_10_5",
+        url = "https://crates.io/api/v1/crates/digest/0.10.5/download",
+        type = "tar.gz",
+        sha256 = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c",
+        strip_prefix = "digest-0.10.5",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.digest-0.10.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__generic_array__0_14_6",
+        url = "https://crates.io/api/v1/crates/generic-array/0.14.6/download",
+        type = "tar.gz",
+        sha256 = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9",
+        strip_prefix = "generic-array-0.14.6",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.generic-array-0.14.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ghost__0_1_6",
+        url = "https://crates.io/api/v1/crates/ghost/0.1.6/download",
+        type = "tar.gz",
+        sha256 = "eb19fe8de3ea0920d282f7b77dd4227aea6b8b999b42cdf0ca41b2472b14443a",
+        strip_prefix = "ghost-0.1.6",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.ghost-0.1.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__hashbrown__0_12_3",
+        url = "https://crates.io/api/v1/crates/hashbrown/0.12.3/download",
+        type = "tar.gz",
+        sha256 = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+        strip_prefix = "hashbrown-0.12.3",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.hashbrown-0.12.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__heck__0_4_0",
+        url = "https://crates.io/api/v1/crates/heck/0.4.0/download",
+        type = "tar.gz",
+        sha256 = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9",
+        strip_prefix = "heck-0.4.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.heck-0.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__hermit_abi__0_1_19",
+        url = "https://crates.io/api/v1/crates/hermit-abi/0.1.19/download",
+        type = "tar.gz",
+        sha256 = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
+        strip_prefix = "hermit-abi-0.1.19",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.hermit-abi-0.1.19.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__indexmap__1_9_1",
+        url = "https://crates.io/api/v1/crates/indexmap/1.9.1/download",
+        type = "tar.gz",
+        sha256 = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e",
+        strip_prefix = "indexmap-1.9.1",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.indexmap-1.9.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__inventory__0_2_3",
+        url = "https://crates.io/api/v1/crates/inventory/0.2.3/download",
+        type = "tar.gz",
+        sha256 = "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a",
+        strip_prefix = "inventory-0.2.3",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.inventory-0.2.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__itoa__1_0_3",
+        url = "https://crates.io/api/v1/crates/itoa/1.0.3/download",
+        type = "tar.gz",
+        sha256 = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754",
+        strip_prefix = "itoa-1.0.3",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.itoa-1.0.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__json5__0_4_1",
+        url = "https://crates.io/api/v1/crates/json5/0.4.1/download",
+        type = "tar.gz",
+        sha256 = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1",
+        strip_prefix = "json5-0.4.1",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.json5-0.4.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__libc__0_2_133",
+        url = "https://crates.io/api/v1/crates/libc/0.2.133/download",
+        type = "tar.gz",
+        sha256 = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966",
+        strip_prefix = "libc-0.2.133",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.libc-0.2.133.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__linked_hash_map__0_5_6",
+        url = "https://crates.io/api/v1/crates/linked-hash-map/0.5.6/download",
+        type = "tar.gz",
+        sha256 = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f",
+        strip_prefix = "linked-hash-map-0.5.6",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.linked-hash-map-0.5.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__memchr__2_5_0",
+        url = "https://crates.io/api/v1/crates/memchr/2.5.0/download",
+        type = "tar.gz",
+        sha256 = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+        strip_prefix = "memchr-2.5.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.memchr-2.5.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__num_traits__0_2_15",
+        url = "https://crates.io/api/v1/crates/num-traits/0.2.15/download",
+        type = "tar.gz",
+        sha256 = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+        strip_prefix = "num-traits-0.2.15",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.num-traits-0.2.15.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__once_cell__1_14_0",
+        url = "https://crates.io/api/v1/crates/once_cell/1.14.0/download",
+        type = "tar.gz",
+        sha256 = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0",
+        strip_prefix = "once_cell-1.14.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.once_cell-1.14.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__os_str_bytes__6_3_0",
+        url = "https://crates.io/api/v1/crates/os_str_bytes/6.3.0/download",
+        type = "tar.gz",
+        sha256 = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff",
+        strip_prefix = "os_str_bytes-6.3.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.os_str_bytes-6.3.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__pest__2_3_1",
+        url = "https://crates.io/api/v1/crates/pest/2.3.1/download",
+        type = "tar.gz",
+        sha256 = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048",
+        strip_prefix = "pest-2.3.1",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.pest-2.3.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__pest_derive__2_3_1",
+        url = "https://crates.io/api/v1/crates/pest_derive/2.3.1/download",
+        type = "tar.gz",
+        sha256 = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1",
+        strip_prefix = "pest_derive-2.3.1",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.pest_derive-2.3.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__pest_generator__2_3_1",
+        url = "https://crates.io/api/v1/crates/pest_generator/2.3.1/download",
+        type = "tar.gz",
+        sha256 = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c",
+        strip_prefix = "pest_generator-2.3.1",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.pest_generator-2.3.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__pest_meta__2_3_1",
+        url = "https://crates.io/api/v1/crates/pest_meta/2.3.1/download",
+        type = "tar.gz",
+        sha256 = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6",
+        strip_prefix = "pest_meta-2.3.1",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.pest_meta-2.3.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__proc_macro_error__1_0_4",
+        url = "https://crates.io/api/v1/crates/proc-macro-error/1.0.4/download",
+        type = "tar.gz",
+        sha256 = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c",
+        strip_prefix = "proc-macro-error-1.0.4",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.proc-macro-error-1.0.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__proc_macro_error_attr__1_0_4",
+        url = "https://crates.io/api/v1/crates/proc-macro-error-attr/1.0.4/download",
+        type = "tar.gz",
+        sha256 = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869",
+        strip_prefix = "proc-macro-error-attr-1.0.4",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.proc-macro-error-attr-1.0.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__proc_macro2__1_0_43",
+        url = "https://crates.io/api/v1/crates/proc-macro2/1.0.43/download",
+        type = "tar.gz",
+        sha256 = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab",
+        strip_prefix = "proc-macro2-1.0.43",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.proc-macro2-1.0.43.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__quote__1_0_21",
+        url = "https://crates.io/api/v1/crates/quote/1.0.21/download",
+        type = "tar.gz",
+        sha256 = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179",
+        strip_prefix = "quote-1.0.21",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.quote-1.0.21.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__regex__1_6_0",
+        url = "https://crates.io/api/v1/crates/regex/1.6.0/download",
+        type = "tar.gz",
+        sha256 = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b",
+        strip_prefix = "regex-1.6.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.regex-1.6.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__regex_syntax__0_6_27",
+        url = "https://crates.io/api/v1/crates/regex-syntax/0.6.27/download",
+        type = "tar.gz",
+        sha256 = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244",
+        strip_prefix = "regex-syntax-0.6.27",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.regex-syntax-0.6.27.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ryu__1_0_11",
+        url = "https://crates.io/api/v1/crates/ryu/1.0.11/download",
+        type = "tar.gz",
+        sha256 = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09",
+        strip_prefix = "ryu-1.0.11",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.ryu-1.0.11.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__serde__1_0_144",
+        url = "https://crates.io/api/v1/crates/serde/1.0.144/download",
+        type = "tar.gz",
+        sha256 = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860",
+        strip_prefix = "serde-1.0.144",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.serde-1.0.144.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__serde_bytes__0_11_7",
+        url = "https://crates.io/api/v1/crates/serde_bytes/0.11.7/download",
+        type = "tar.gz",
+        sha256 = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b",
+        strip_prefix = "serde_bytes-0.11.7",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.serde_bytes-0.11.7.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__serde_derive__1_0_144",
+        url = "https://crates.io/api/v1/crates/serde_derive/1.0.144/download",
+        type = "tar.gz",
+        sha256 = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00",
+        strip_prefix = "serde_derive-1.0.144",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.serde_derive-1.0.144.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__serde_json__1_0_85",
+        url = "https://crates.io/api/v1/crates/serde_json/1.0.85/download",
+        type = "tar.gz",
+        sha256 = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44",
+        strip_prefix = "serde_json-1.0.85",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.serde_json-1.0.85.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__serde_yaml__0_8_26",
+        url = "https://crates.io/api/v1/crates/serde_yaml/0.8.26/download",
+        type = "tar.gz",
+        sha256 = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b",
+        strip_prefix = "serde_yaml-0.8.26",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.serde_yaml-0.8.26.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__sha1__0_10_5",
+        url = "https://crates.io/api/v1/crates/sha1/0.10.5/download",
+        type = "tar.gz",
+        sha256 = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3",
+        strip_prefix = "sha1-0.10.5",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.sha1-0.10.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__strsim__0_10_0",
+        url = "https://crates.io/api/v1/crates/strsim/0.10.0/download",
+        type = "tar.gz",
+        sha256 = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+        strip_prefix = "strsim-0.10.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.strsim-0.10.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__syn__1_0_100",
+        url = "https://crates.io/api/v1/crates/syn/1.0.100/download",
+        type = "tar.gz",
+        sha256 = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e",
+        strip_prefix = "syn-1.0.100",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.syn-1.0.100.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__termcolor__1_1_3",
+        url = "https://crates.io/api/v1/crates/termcolor/1.1.3/download",
+        type = "tar.gz",
+        sha256 = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755",
+        strip_prefix = "termcolor-1.1.3",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.termcolor-1.1.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__textwrap__0_15_1",
+        url = "https://crates.io/api/v1/crates/textwrap/0.15.1/download",
+        type = "tar.gz",
+        sha256 = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16",
+        strip_prefix = "textwrap-0.15.1",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.textwrap-0.15.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__thiserror__1_0_35",
+        url = "https://crates.io/api/v1/crates/thiserror/1.0.35/download",
+        type = "tar.gz",
+        sha256 = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85",
+        strip_prefix = "thiserror-1.0.35",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-1.0.35.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__thiserror_impl__1_0_35",
+        url = "https://crates.io/api/v1/crates/thiserror-impl/1.0.35/download",
+        type = "tar.gz",
+        sha256 = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783",
+        strip_prefix = "thiserror-impl-1.0.35",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.thiserror-impl-1.0.35.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__typenum__1_15_0",
+        url = "https://crates.io/api/v1/crates/typenum/1.15.0/download",
+        type = "tar.gz",
+        sha256 = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987",
+        strip_prefix = "typenum-1.15.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.typenum-1.15.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ucd_trie__0_1_5",
+        url = "https://crates.io/api/v1/crates/ucd-trie/0.1.5/download",
+        type = "tar.gz",
+        sha256 = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81",
+        strip_prefix = "ucd-trie-0.1.5",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.ucd-trie-0.1.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__unicode_ident__1_0_4",
+        url = "https://crates.io/api/v1/crates/unicode-ident/1.0.4/download",
+        type = "tar.gz",
+        sha256 = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd",
+        strip_prefix = "unicode-ident-1.0.4",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.unicode-ident-1.0.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__version_check__0_9_4",
+        url = "https://crates.io/api/v1/crates/version_check/0.9.4/download",
+        type = "tar.gz",
+        sha256 = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+        strip_prefix = "version_check-0.9.4",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.version_check-0.9.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__winapi__0_3_9",
+        url = "https://crates.io/api/v1/crates/winapi/0.3.9/download",
+        type = "tar.gz",
+        sha256 = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        strip_prefix = "winapi-0.3.9",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.winapi-0.3.9.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__winapi_i686_pc_windows_gnu__0_4_0",
+        url = "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
+        type = "tar.gz",
+        sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__winapi_util__0_1_5",
+        url = "https://crates.io/api/v1/crates/winapi-util/0.1.5/download",
+        type = "tar.gz",
+        sha256 = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+        strip_prefix = "winapi-util-0.1.5",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.winapi-util-0.1.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__winapi_x86_64_pc_windows_gnu__0_4_0",
+        url = "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
+        type = "tar.gz",
+        sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__yaml_rust__0_4_5",
+        url = "https://crates.io/api/v1/crates/yaml-rust/0.4.5/download",
+        type = "tar.gz",
+        sha256 = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85",
+        strip_prefix = "yaml-rust-0.4.5",
+        build_file = Label("//third_party/rust/crates/remote:BUILD.yaml-rust-0.4.5.bazel"),
+    )

--- a/third_party/rust/crates/remote/BUILD.aho-corasick-0.7.19.bazel
+++ b/third_party/rust/crates/remote/BUILD.aho-corasick-0.7.19.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "aho_corasick",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=aho_corasick",
+        "manual",
+    ],
+    version = "0.7.19",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__memchr__2_5_0//:memchr",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.ansi_term-0.12.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.ansi_term-0.12.1.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "256_colours" with type "example" omitted
+
+# Unsupported target "basic_colours" with type "example" omitted
+
+# Unsupported target "rgb_colours" with type "example" omitted
+
+rust_library(
+    name = "ansi_term",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=ansi_term",
+        "manual",
+    ],
+    version = "0.12.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.anyhow-1.0.65.bazel
+++ b/third_party/rust/crates/remote/BUILD.anyhow-1.0.65.bazel
@@ -1,0 +1,116 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "anyhow_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.65",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "anyhow",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=anyhow",
+        "manual",
+    ],
+    version = "1.0.65",
+    # buildifier: leave-alone
+    deps = [
+        ":anyhow_build_script",
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "test_autotrait" with type "test" omitted
+
+# Unsupported target "test_backtrace" with type "test" omitted
+
+# Unsupported target "test_boxed" with type "test" omitted
+
+# Unsupported target "test_chain" with type "test" omitted
+
+# Unsupported target "test_context" with type "test" omitted
+
+# Unsupported target "test_convert" with type "test" omitted
+
+# Unsupported target "test_downcast" with type "test" omitted
+
+# Unsupported target "test_ensure" with type "test" omitted
+
+# Unsupported target "test_ffi" with type "test" omitted
+
+# Unsupported target "test_fmt" with type "test" omitted
+
+# Unsupported target "test_macros" with type "test" omitted
+
+# Unsupported target "test_repr" with type "test" omitted
+
+# Unsupported target "test_source" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.atty-0.2.14.bazel
+++ b/third_party/rust/crates/remote/BUILD.atty-0.2.14.bazel
@@ -1,0 +1,66 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "atty" with type "example" omitted
+
+rust_library(
+    name = "atty",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=atty",
+        "manual",
+    ],
+    version = "0.2.14",
+    # buildifier: leave-alone
+    deps = [
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_133//:libc",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/rust/crates/remote/BUILD.autocfg-1.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.autocfg-1.1.0.bazel
@@ -1,0 +1,64 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "integers" with type "example" omitted
+
+# Unsupported target "paths" with type "example" omitted
+
+# Unsupported target "traits" with type "example" omitted
+
+# Unsupported target "versions" with type "example" omitted
+
+rust_library(
+    name = "autocfg",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=autocfg",
+        "manual",
+    ],
+    version = "1.1.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "rustflags" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.bazel
+++ b/third_party/rust/crates/remote/BUILD.bazel
@@ -1,0 +1,17 @@
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/rust/crates/remote/BUILD.bitflags-1.3.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.bitflags-1.3.2.bazel
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "bitflags",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=bitflags",
+        "manual",
+    ],
+    version = "1.3.2",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "basic" with type "test" omitted
+
+# Unsupported target "compile" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.block-buffer-0.10.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.block-buffer-0.10.3.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "block_buffer",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=block-buffer",
+        "manual",
+    ],
+    version = "0.10.3",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__generic_array__0_14_6//:generic_array",
+    ],
+)
+
+# Unsupported target "mod" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.cfg-if-1.0.0.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "cfg_if",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=cfg-if",
+        "manual",
+    ],
+    version = "1.0.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "xcrate" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.clap-3.2.22.bazel
+++ b/third_party/rust/crates/remote/BUILD.clap-3.2.22.bazel
@@ -1,0 +1,225 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_binary(
+    # Prefix bin name to disambiguate from (probable) collision with lib name
+    # N.B.: The exact form of this is subject to change.
+    name = "cargo_bin_stdio_fixture",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "atty",
+        "clap_derive",
+        "color",
+        "default",
+        "derive",
+        "once_cell",
+        "std",
+        "strsim",
+        "suggestions",
+        "termcolor",
+    ],
+    crate_root = "src/bin/stdio-fixture.rs",
+    data = [],
+    compile_data = glob([ "*.md", "**/*.md" ]),
+    edition = "2021",
+    proc_macro_deps = [
+        "@raze__clap_derive__3_2_18//:clap_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=stdio-fixture",
+        "manual",
+    ],
+    version = "3.2.22",
+    # buildifier: leave-alone
+    deps = [
+        ":clap",
+        "@raze__atty__0_2_14//:atty",
+        "@raze__bitflags__1_3_2//:bitflags",
+        "@raze__clap_lex__0_2_4//:clap_lex",
+        "@raze__indexmap__1_9_1//:indexmap",
+        "@raze__once_cell__1_14_0//:once_cell",
+        "@raze__strsim__0_10_0//:strsim",
+        "@raze__termcolor__1_1_3//:termcolor",
+        "@raze__textwrap__0_15_1//:textwrap",
+    ],
+)
+
+# Unsupported target "01_quick" with type "example" omitted
+
+# Unsupported target "01_quick_derive" with type "example" omitted
+
+# Unsupported target "02_app_settings" with type "example" omitted
+
+# Unsupported target "02_app_settings_derive" with type "example" omitted
+
+# Unsupported target "02_apps" with type "example" omitted
+
+# Unsupported target "02_apps_derive" with type "example" omitted
+
+# Unsupported target "02_crate" with type "example" omitted
+
+# Unsupported target "02_crate_derive" with type "example" omitted
+
+# Unsupported target "03_01_flag_bool" with type "example" omitted
+
+# Unsupported target "03_01_flag_bool_derive" with type "example" omitted
+
+# Unsupported target "03_01_flag_count" with type "example" omitted
+
+# Unsupported target "03_01_flag_count_derive" with type "example" omitted
+
+# Unsupported target "03_02_option" with type "example" omitted
+
+# Unsupported target "03_02_option_derive" with type "example" omitted
+
+# Unsupported target "03_03_positional" with type "example" omitted
+
+# Unsupported target "03_03_positional_derive" with type "example" omitted
+
+# Unsupported target "03_04_subcommands" with type "example" omitted
+
+# Unsupported target "03_04_subcommands_alt_derive" with type "example" omitted
+
+# Unsupported target "03_04_subcommands_derive" with type "example" omitted
+
+# Unsupported target "03_05_default_values" with type "example" omitted
+
+# Unsupported target "03_05_default_values_derive" with type "example" omitted
+
+# Unsupported target "04_01_enum" with type "example" omitted
+
+# Unsupported target "04_01_enum_derive" with type "example" omitted
+
+# Unsupported target "04_01_possible" with type "example" omitted
+
+# Unsupported target "04_02_parse" with type "example" omitted
+
+# Unsupported target "04_02_parse_derive" with type "example" omitted
+
+# Unsupported target "04_02_validate" with type "example" omitted
+
+# Unsupported target "04_02_validate_derive" with type "example" omitted
+
+# Unsupported target "04_03_relations" with type "example" omitted
+
+# Unsupported target "04_03_relations_derive" with type "example" omitted
+
+# Unsupported target "04_04_custom" with type "example" omitted
+
+# Unsupported target "04_04_custom_derive" with type "example" omitted
+
+# Unsupported target "05_01_assert" with type "example" omitted
+
+# Unsupported target "05_01_assert_derive" with type "example" omitted
+
+# Unsupported target "busybox" with type "example" omitted
+
+# Unsupported target "cargo-example" with type "example" omitted
+
+# Unsupported target "cargo-example-derive" with type "example" omitted
+
+# Unsupported target "custom-bool" with type "example" omitted
+
+# Unsupported target "demo" with type "example" omitted
+
+# Unsupported target "escaped-positional" with type "example" omitted
+
+# Unsupported target "escaped-positional-derive" with type "example" omitted
+
+# Unsupported target "git" with type "example" omitted
+
+# Unsupported target "git-derive" with type "example" omitted
+
+# Unsupported target "hostname" with type "example" omitted
+
+# Unsupported target "interop_augment_args" with type "example" omitted
+
+# Unsupported target "interop_augment_subcommands" with type "example" omitted
+
+# Unsupported target "interop_flatten_hand_args" with type "example" omitted
+
+# Unsupported target "interop_hand_subcommand" with type "example" omitted
+
+# Unsupported target "pacman" with type "example" omitted
+
+# Unsupported target "repl" with type "example" omitted
+
+# Unsupported target "typed-derive" with type "example" omitted
+
+rust_library(
+    name = "clap",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "atty",
+        "clap_derive",
+        "color",
+        "default",
+        "derive",
+        "once_cell",
+        "std",
+        "strsim",
+        "suggestions",
+        "termcolor",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    compile_data = glob([ "*.md", "**/*.md" ]),
+    edition = "2021",
+    proc_macro_deps = [
+        "@raze__clap_derive__3_2_18//:clap_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=clap",
+        "manual",
+    ],
+    version = "3.2.22",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__atty__0_2_14//:atty",
+        "@raze__bitflags__1_3_2//:bitflags",
+        "@raze__clap_lex__0_2_4//:clap_lex",
+        "@raze__indexmap__1_9_1//:indexmap",
+        "@raze__once_cell__1_14_0//:once_cell",
+        "@raze__strsim__0_10_0//:strsim",
+        "@raze__termcolor__1_1_3//:termcolor",
+        "@raze__textwrap__0_15_1//:textwrap",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.clap_derive-3.2.18.bazel
+++ b/third_party/rust/crates/remote/BUILD.clap_derive-3.2.18.bazel
@@ -1,0 +1,61 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_proc_macro(
+    name = "clap_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    compile_data = glob([ "*.md", "**/*.md" ]),
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=clap_derive",
+        "manual",
+    ],
+    version = "3.2.18",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__heck__0_4_0//:heck",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__proc_macro_error__1_0_4//:proc_macro_error",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.clap_lex-0.2.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.clap_lex-0.2.4.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "clap_lex",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=clap_lex",
+        "manual",
+    ],
+    version = "0.2.4",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__os_str_bytes__6_3_0//:os_str_bytes",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.cpufeatures-0.2.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.cpufeatures-0.2.5.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "cpufeatures",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=cpufeatures",
+        "manual",
+    ],
+    version = "0.2.5",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "aarch64" with type "test" omitted
+
+# Unsupported target "x86" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.crypto-common-0.1.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.crypto-common-0.1.6.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "crypto_common",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=crypto-common",
+        "manual",
+    ],
+    version = "0.1.6",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__generic_array__0_14_6//:generic_array",
+        "@raze__typenum__1_15_0//:typenum",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.ctor-0.1.23.bazel
+++ b/third_party/rust/crates/remote/BUILD.ctor-0.1.23.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "example" with type "example" omitted
+
+rust_proc_macro(
+    name = "ctor",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=ctor",
+        "manual",
+    ],
+    version = "0.1.23",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.deser-hjson-1.0.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.deser-hjson-1.0.2.bazel
@@ -1,0 +1,75 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "parse" with type "bench" omitted
+
+rust_library(
+    name = "deser_hjson",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=deser-hjson",
+        "manual",
+    ],
+    version = "1.0.2",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__serde__1_0_144//:serde",
+    ],
+)
+
+# Unsupported target "bad_format" with type "test" omitted
+
+# Unsupported target "crlf" with type "test" omitted
+
+# Unsupported target "enum" with type "test" omitted
+
+# Unsupported target "guess" with type "test" omitted
+
+# Unsupported target "mix" with type "test" omitted
+
+# Unsupported target "serde-error" with type "test" omitted
+
+# Unsupported target "spacing" with type "test" omitted
+
+# Unsupported target "strings" with type "test" omitted
+
+# Unsupported target "trailing_chars" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.digest-0.10.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.digest-0.10.5.bazel
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "digest",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "block-buffer",
+        "core-api",
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=digest",
+        "manual",
+    ],
+    version = "0.10.5",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__block_buffer__0_10_3//:block_buffer",
+        "@raze__crypto_common__0_1_6//:crypto_common",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.generic-array-0.14.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.generic-array-0.14.6.bazel
@@ -1,0 +1,88 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "generic_array_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "more_lengths",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.14.6",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__version_check__0_9_4//:version_check",
+    ],
+)
+
+rust_library(
+    name = "generic_array",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "more_lengths",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=generic_array",
+        "manual",
+    ],
+    version = "0.14.6",
+    # buildifier: leave-alone
+    deps = [
+        ":generic_array_build_script",
+        "@raze__typenum__1_15_0//:typenum",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.ghost-0.1.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.ghost-0.1.6.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_proc_macro(
+    name = "ghost",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=ghost",
+        "manual",
+    ],
+    version = "0.1.6",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
+    ],
+)
+
+# Unsupported target "autotraits" with type "test" omitted
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "readme" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.hashbrown-0.12.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.hashbrown-0.12.3.bazel
@@ -1,0 +1,67 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "insert_unique_unchecked" with type "bench" omitted
+
+rust_library(
+    name = "hashbrown",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "raw",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=hashbrown",
+        "manual",
+    ],
+    version = "0.12.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "hasher" with type "test" omitted
+
+# Unsupported target "rayon" with type "test" omitted
+
+# Unsupported target "serde" with type "test" omitted
+
+# Unsupported target "set" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.heck-0.4.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.heck-0.4.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "heck",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=heck",
+        "manual",
+    ],
+    version = "0.4.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.hermit-abi-0.1.19.bazel
+++ b/third_party/rust/crates/remote/BUILD.hermit-abi-0.1.19.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "hermit_abi",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=hermit-abi",
+        "manual",
+    ],
+    version = "0.1.19",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__libc__0_2_133//:libc",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.indexmap-1.9.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.indexmap-1.9.1.bazel
@@ -1,0 +1,100 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "indexmap_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.9.1",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__autocfg__1_1_0//:autocfg",
+    ],
+)
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "faststring" with type "bench" omitted
+
+rust_library(
+    name = "indexmap",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=indexmap",
+        "manual",
+    ],
+    version = "1.9.1",
+    # buildifier: leave-alone
+    deps = [
+        ":indexmap_build_script",
+        "@raze__hashbrown__0_12_3//:hashbrown",
+    ],
+)
+
+# Unsupported target "equivalent_trait" with type "test" omitted
+
+# Unsupported target "macros_full_path" with type "test" omitted
+
+# Unsupported target "quick" with type "test" omitted
+
+# Unsupported target "tests" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.inventory-0.2.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.inventory-0.2.3.bazel
@@ -1,0 +1,62 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "flags" with type "example" omitted
+
+rust_library(
+    name = "inventory",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__ctor__0_1_23//:ctor",
+        "@raze__ghost__0_1_6//:ghost",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=inventory",
+        "manual",
+    ],
+    version = "0.2.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.itoa-1.0.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.itoa-1.0.3.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "itoa",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=itoa",
+        "manual",
+    ],
+    version = "1.0.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.json5-0.4.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.json5-0.4.1.bazel
@@ -1,0 +1,72 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # ISC from expression "ISC"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "json5",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    compile_data = [ "src/json5.pest" ],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__pest_derive__2_3_1//:pest_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=json5",
+        "manual",
+    ],
+    version = "0.4.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__pest__2_3_1//:pest",
+        "@raze__serde__1_0_144//:serde",
+    ],
+)
+
+# Unsupported target "adapted_from_js_reference" with type "test" omitted
+
+# Unsupported target "common" with type "test" omitted
+
+# Unsupported target "de" with type "test" omitted
+
+# Unsupported target "examples" with type "test" omitted
+
+# Unsupported target "json5_dot_org_example" with type "test" omitted
+
+# Unsupported target "ser" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.libc-0.2.133.bazel
+++ b/third_party/rust/crates/remote/BUILD.libc-0.2.133.bazel
@@ -1,0 +1,90 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "libc_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.133",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "libc",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=libc",
+        "manual",
+    ],
+    version = "0.2.133",
+    # buildifier: leave-alone
+    deps = [
+        ":libc_build_script",
+    ],
+)
+
+# Unsupported target "const_fn" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.linked-hash-map-0.5.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.linked-hash-map-0.5.6.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "linked_hash_map",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=linked-hash-map",
+        "manual",
+    ],
+    version = "0.5.6",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.memchr-2.5.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.memchr-2.5.0.bazel
@@ -1,0 +1,88 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "memchr_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "2.5.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "memchr",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=memchr",
+        "manual",
+    ],
+    version = "2.5.0",
+    # buildifier: leave-alone
+    deps = [
+        ":memchr_build_script",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.num-traits-0.2.15.bazel
+++ b/third_party/rust/crates/remote/BUILD.num-traits-0.2.15.bazel
@@ -1,0 +1,91 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "num_traits_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.15",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__autocfg__1_1_0//:autocfg",
+    ],
+)
+
+rust_library(
+    name = "num_traits",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=num-traits",
+        "manual",
+    ],
+    version = "0.2.15",
+    # buildifier: leave-alone
+    deps = [
+        ":num_traits_build_script",
+    ],
+)
+
+# Unsupported target "cast" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.once_cell-1.14.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.once_cell-1.14.0.bazel
@@ -1,0 +1,74 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "example" omitted
+
+# Unsupported target "bench_acquire" with type "example" omitted
+
+# Unsupported target "bench_vs_lazy_static" with type "example" omitted
+
+# Unsupported target "lazy_static" with type "example" omitted
+
+# Unsupported target "reentrant_init_deadlocks" with type "example" omitted
+
+# Unsupported target "regex" with type "example" omitted
+
+# Unsupported target "test_synchronization" with type "example" omitted
+
+rust_library(
+    name = "once_cell",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "default",
+        "race",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=once_cell",
+        "manual",
+    ],
+    version = "1.14.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "it" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.os_str_bytes-6.3.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.os_str_bytes-6.3.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "os_str_bytes",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "raw_os_str",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=os_str_bytes",
+        "manual",
+    ],
+    version = "6.3.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.pest-2.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.pest-2.3.1.bazel
@@ -1,0 +1,65 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "parens" with type "example" omitted
+
+rust_library(
+    name = "pest",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+        "thiserror",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=pest",
+        "manual",
+    ],
+    version = "2.3.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__thiserror__1_0_35//:thiserror",
+        "@raze__ucd_trie__0_1_5//:ucd_trie",
+    ],
+)
+
+# Unsupported target "calculator" with type "test" omitted
+
+# Unsupported target "json" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.pest_derive-2.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.pest_derive-2.3.1.bazel
@@ -1,0 +1,66 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_proc_macro(
+    name = "pest_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=pest_derive",
+        "manual",
+    ],
+    version = "2.3.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__pest__2_3_1//:pest",
+        "@raze__pest_generator__2_3_1//:pest_generator",
+    ],
+)
+
+# Unsupported target "grammar" with type "test" omitted
+
+# Unsupported target "grammar_inline" with type "test" omitted
+
+# Unsupported target "lists" with type "test" omitted
+
+# Unsupported target "reporting" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.pest_generator-2.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.pest_generator-2.3.1.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "pest_generator",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=pest_generator",
+        "manual",
+    ],
+    version = "2.3.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__pest__2_3_1//:pest",
+        "@raze__pest_meta__2_3_1//:pest_meta",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.pest_meta-2.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.pest_meta-2.3.1.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "pest_meta",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=pest_meta",
+        "manual",
+    ],
+    version = "2.3.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__once_cell__1_14_0//:once_cell",
+        "@raze__pest__2_3_1//:pest",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -1,0 +1,103 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "proc_macro_error_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "syn",
+        "syn-error",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.4",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__version_check__0_9_4//:version_check",
+    ],
+)
+
+rust_library(
+    name = "proc_macro_error",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "syn",
+        "syn-error",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__proc_macro_error_attr__1_0_4//:proc_macro_error_attr",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=proc-macro-error",
+        "manual",
+    ],
+    version = "1.0.4",
+    # buildifier: leave-alone
+    deps = [
+        ":proc_macro_error_build_script",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
+    ],
+)
+
+# Unsupported target "macro-errors" with type "test" omitted
+
+# Unsupported target "ok" with type "test" omitted
+
+# Unsupported target "runtime-errors" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -1,0 +1,87 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "proc_macro_error_attr_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.4",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__version_check__0_9_4//:version_check",
+    ],
+)
+
+rust_proc_macro(
+    name = "proc_macro_error_attr",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=proc-macro-error-attr",
+        "manual",
+    ],
+    version = "1.0.4",
+    # buildifier: leave-alone
+    deps = [
+        ":proc_macro_error_attr_build_script",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.proc-macro2-1.0.43.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro2-1.0.43.bazel
@@ -1,0 +1,99 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "proc_macro2_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.43",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "proc_macro2",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=proc-macro2",
+        "manual",
+    ],
+    version = "1.0.43",
+    # buildifier: leave-alone
+    deps = [
+        ":proc_macro2_build_script",
+        "@raze__unicode_ident__1_0_4//:unicode_ident",
+    ],
+)
+
+# Unsupported target "comments" with type "test" omitted
+
+# Unsupported target "features" with type "test" omitted
+
+# Unsupported target "marker" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted
+
+# Unsupported target "test_fmt" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.quote-1.0.21.bazel
+++ b/third_party/rust/crates/remote/BUILD.quote-1.0.21.bazel
@@ -1,0 +1,93 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "quote_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.21",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "quote",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=quote",
+        "manual",
+    ],
+    version = "1.0.21",
+    # buildifier: leave-alone
+    deps = [
+        ":quote_build_script",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.regex-1.6.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.regex-1.6.0.bazel
@@ -1,0 +1,104 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "shootout-regex-dna" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-bytes" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-cheat" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-replace" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-single" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-single-cheat" with type "example" omitted
+
+rust_library(
+    name = "regex",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "aho-corasick",
+        "default",
+        "memchr",
+        "perf",
+        "perf-cache",
+        "perf-dfa",
+        "perf-inline",
+        "perf-literal",
+        "std",
+        "unicode",
+        "unicode-age",
+        "unicode-bool",
+        "unicode-case",
+        "unicode-gencat",
+        "unicode-perl",
+        "unicode-script",
+        "unicode-segment",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=regex",
+        "manual",
+    ],
+    version = "1.6.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__aho_corasick__0_7_19//:aho_corasick",
+        "@raze__memchr__2_5_0//:memchr",
+        "@raze__regex_syntax__0_6_27//:regex_syntax",
+    ],
+)
+
+# Unsupported target "backtrack" with type "test" omitted
+
+# Unsupported target "backtrack-bytes" with type "test" omitted
+
+# Unsupported target "backtrack-utf8bytes" with type "test" omitted
+
+# Unsupported target "crates-regex" with type "test" omitted
+
+# Unsupported target "default" with type "test" omitted
+
+# Unsupported target "default-bytes" with type "test" omitted
+
+# Unsupported target "nfa" with type "test" omitted
+
+# Unsupported target "nfa-bytes" with type "test" omitted
+
+# Unsupported target "nfa-utf8bytes" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.regex-syntax-0.6.27.bazel
+++ b/third_party/rust/crates/remote/BUILD.regex-syntax-0.6.27.bazel
@@ -1,0 +1,65 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "regex_syntax",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "unicode",
+        "unicode-age",
+        "unicode-bool",
+        "unicode-case",
+        "unicode-gencat",
+        "unicode-perl",
+        "unicode-script",
+        "unicode-segment",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=regex-syntax",
+        "manual",
+    ],
+    version = "0.6.27",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.ryu-1.0.11.bazel
+++ b/third_party/rust/crates/remote/BUILD.ryu-1.0.11.bazel
@@ -1,0 +1,72 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR BSL-1.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "upstream_benchmark" with type "example" omitted
+
+rust_library(
+    name = "ryu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=ryu",
+        "manual",
+    ],
+    version = "1.0.11",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "common_test" with type "test" omitted
+
+# Unsupported target "d2s_table_test" with type "test" omitted
+
+# Unsupported target "d2s_test" with type "test" omitted
+
+# Unsupported target "exhaustive" with type "test" omitted
+
+# Unsupported target "f2s_test" with type "test" omitted
+
+# Unsupported target "s2d_test" with type "test" omitted
+
+# Unsupported target "s2f_test" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.serde-1.0.144.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde-1.0.144.bazel
@@ -1,0 +1,95 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "serde_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.144",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "serde",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "derive",
+        "serde_derive",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    proc_macro_deps = [
+        "@raze__serde_derive__1_0_144//:serde_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=serde",
+        "manual",
+    ],
+    version = "1.0.144",
+    # buildifier: leave-alone
+    deps = [
+        ":serde_build_script",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.serde_bytes-0.11.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_bytes-0.11.7.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "serde_bytes",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=serde_bytes",
+        "manual",
+    ],
+    version = "0.11.7",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__serde__1_0_144//:serde",
+    ],
+)
+
+# Unsupported target "test_derive" with type "test" omitted
+
+# Unsupported target "test_partialeq" with type "test" omitted
+
+# Unsupported target "test_serde" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.serde_derive-1.0.144.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_derive-1.0.144.bazel
@@ -1,0 +1,89 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "serde_derive_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.144",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_proc_macro(
+    name = "serde_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=serde_derive",
+        "manual",
+    ],
+    version = "1.0.144",
+    # buildifier: leave-alone
+    deps = [
+        ":serde_derive_build_script",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.serde_json-1.0.85.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_json-1.0.85.bazel
@@ -1,0 +1,105 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "serde_json_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.85",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "serde_json",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=serde_json",
+        "manual",
+    ],
+    version = "1.0.85",
+    # buildifier: leave-alone
+    deps = [
+        ":serde_json_build_script",
+        "@raze__itoa__1_0_3//:itoa",
+        "@raze__ryu__1_0_11//:ryu",
+        "@raze__serde__1_0_144//:serde",
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "debug" with type "test" omitted
+
+# Unsupported target "lexical" with type "test" omitted
+
+# Unsupported target "map" with type "test" omitted
+
+# Unsupported target "regression" with type "test" omitted
+
+# Unsupported target "stream" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.serde_yaml-0.8.26.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_yaml-0.8.26.bazel
@@ -1,0 +1,66 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "serde_yaml",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=serde_yaml",
+        "manual",
+    ],
+    version = "0.8.26",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__indexmap__1_9_1//:indexmap",
+        "@raze__ryu__1_0_11//:ryu",
+        "@raze__serde__1_0_144//:serde",
+        "@raze__yaml_rust__0_4_5//:yaml_rust",
+    ],
+)
+
+# Unsupported target "test_de" with type "test" omitted
+
+# Unsupported target "test_error" with type "test" omitted
+
+# Unsupported target "test_serde" with type "test" omitted
+
+# Unsupported target "test_value" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.sha1-0.10.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.sha1-0.10.5.bazel
@@ -1,0 +1,70 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "mod" with type "bench" omitted
+
+rust_library(
+    name = "sha1",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=sha1",
+        "manual",
+    ],
+    version = "0.10.5",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__digest__0_10_5//:digest",
+    ] + selects.with_or({
+        # cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))
+        (
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__cpufeatures__0_2_5//:cpufeatures",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "mod" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.strsim-0.10.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.strsim-0.10.0.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "benches" with type "bench" omitted
+
+rust_library(
+    name = "strsim",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=strsim",
+        "manual",
+    ],
+    version = "0.10.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "lib" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.syn-1.0.100.bazel
+++ b/third_party/rust/crates/remote/BUILD.syn-1.0.100.bazel
@@ -1,0 +1,163 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "syn_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "clone-impls",
+        "default",
+        "derive",
+        "extra-traits",
+        "full",
+        "parsing",
+        "printing",
+        "proc-macro",
+        "quote",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.100",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+# Unsupported target "file" with type "bench" omitted
+
+# Unsupported target "rust" with type "bench" omitted
+
+rust_library(
+    name = "syn",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "clone-impls",
+        "default",
+        "derive",
+        "extra-traits",
+        "full",
+        "parsing",
+        "printing",
+        "proc-macro",
+        "quote",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=syn",
+        "manual",
+    ],
+    version = "1.0.100",
+    # buildifier: leave-alone
+    deps = [
+        ":syn_build_script",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__unicode_ident__1_0_4//:unicode_ident",
+    ],
+)
+
+# Unsupported target "regression" with type "test" omitted
+
+# Unsupported target "test_asyncness" with type "test" omitted
+
+# Unsupported target "test_attribute" with type "test" omitted
+
+# Unsupported target "test_derive_input" with type "test" omitted
+
+# Unsupported target "test_expr" with type "test" omitted
+
+# Unsupported target "test_generics" with type "test" omitted
+
+# Unsupported target "test_grouping" with type "test" omitted
+
+# Unsupported target "test_ident" with type "test" omitted
+
+# Unsupported target "test_item" with type "test" omitted
+
+# Unsupported target "test_iterators" with type "test" omitted
+
+# Unsupported target "test_lit" with type "test" omitted
+
+# Unsupported target "test_meta" with type "test" omitted
+
+# Unsupported target "test_parse_buffer" with type "test" omitted
+
+# Unsupported target "test_parse_stream" with type "test" omitted
+
+# Unsupported target "test_pat" with type "test" omitted
+
+# Unsupported target "test_path" with type "test" omitted
+
+# Unsupported target "test_precedence" with type "test" omitted
+
+# Unsupported target "test_receiver" with type "test" omitted
+
+# Unsupported target "test_round_trip" with type "test" omitted
+
+# Unsupported target "test_shebang" with type "test" omitted
+
+# Unsupported target "test_should_parse" with type "test" omitted
+
+# Unsupported target "test_size" with type "test" omitted
+
+# Unsupported target "test_stmt" with type "test" omitted
+
+# Unsupported target "test_token_trees" with type "test" omitted
+
+# Unsupported target "test_ty" with type "test" omitted
+
+# Unsupported target "test_visibility" with type "test" omitted
+
+# Unsupported target "zzz_stable" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.termcolor-1.1.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.termcolor-1.1.3.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "termcolor",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=termcolor",
+        "manual",
+    ],
+    version = "1.1.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.textwrap-0.15.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.textwrap-0.15.1.bazel
@@ -1,0 +1,68 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "indent" with type "bench" omitted
+
+# Unsupported target "linear" with type "bench" omitted
+
+# Unsupported target "unfill" with type "bench" omitted
+
+# Unsupported target "hyphenation" with type "example" omitted
+
+# Unsupported target "termwidth" with type "example" omitted
+
+rust_library(
+    name = "textwrap",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=textwrap",
+        "manual",
+    ],
+    version = "0.15.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "indent" with type "test" omitted
+
+# Unsupported target "version-numbers" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.thiserror-1.0.35.bazel
+++ b/third_party/rust/crates/remote/BUILD.thiserror-1.0.35.bazel
@@ -1,0 +1,113 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "thiserror_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.35",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "thiserror",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__thiserror_impl__1_0_35//:thiserror_impl",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=thiserror",
+        "manual",
+    ],
+    version = "1.0.35",
+    # buildifier: leave-alone
+    deps = [
+        ":thiserror_build_script",
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "test_backtrace" with type "test" omitted
+
+# Unsupported target "test_deprecated" with type "test" omitted
+
+# Unsupported target "test_display" with type "test" omitted
+
+# Unsupported target "test_error" with type "test" omitted
+
+# Unsupported target "test_expr" with type "test" omitted
+
+# Unsupported target "test_from" with type "test" omitted
+
+# Unsupported target "test_generics" with type "test" omitted
+
+# Unsupported target "test_lints" with type "test" omitted
+
+# Unsupported target "test_option" with type "test" omitted
+
+# Unsupported target "test_path" with type "test" omitted
+
+# Unsupported target "test_source" with type "test" omitted
+
+# Unsupported target "test_transparent" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.thiserror-impl-1.0.35.bazel
+++ b/third_party/rust/crates/remote/BUILD.thiserror-impl-1.0.35.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_proc_macro(
+    name = "thiserror_impl",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=thiserror-impl",
+        "manual",
+    ],
+    version = "1.0.35",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__syn__1_0_100//:syn",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.typenum-1.15.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.typenum-1.15.0.bazel
@@ -1,0 +1,86 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "typenum_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build/main.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.15.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "typenum",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=typenum",
+        "manual",
+    ],
+    version = "1.15.0",
+    # buildifier: leave-alone
+    deps = [
+        ":typenum_build_script",
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.ucd-trie-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.ucd-trie-0.1.5.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "ucd_trie",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=ucd-trie",
+        "manual",
+    ],
+    version = "0.1.5",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.unicode-ident-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-ident-1.0.4.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
+])
+
+# Generated Targets
+
+# Unsupported target "xid" with type "bench" omitted
+
+rust_library(
+    name = "unicode_ident",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=unicode-ident",
+        "manual",
+    ],
+    version = "1.0.4",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "compare" with type "test" omitted
+
+# Unsupported target "static_size" with type "test" omitted

--- a/third_party/rust/crates/remote/BUILD.version_check-0.9.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.version_check-0.9.4.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "version_check",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=version_check",
+        "manual",
+    ],
+    version = "0.9.4",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.winapi-0.3.9.bazel
+++ b/third_party/rust/crates/remote/BUILD.winapi-0.3.9.bazel
@@ -1,0 +1,108 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "winapi_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "consoleapi",
+        "errhandlingapi",
+        "fileapi",
+        "handleapi",
+        "minwinbase",
+        "minwindef",
+        "processenv",
+        "std",
+        "winbase",
+        "wincon",
+        "winerror",
+        "winnt",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.9",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "winapi",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "consoleapi",
+        "errhandlingapi",
+        "fileapi",
+        "handleapi",
+        "minwinbase",
+        "minwindef",
+        "processenv",
+        "std",
+        "winbase",
+        "wincon",
+        "winerror",
+        "winnt",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=winapi",
+        "manual",
+    ],
+    version = "0.3.9",
+    # buildifier: leave-alone
+    deps = [
+        ":winapi_build_script",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -1,0 +1,84 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "winapi_i686_pc_windows_gnu_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "winapi_i686_pc_windows_gnu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=winapi-i686-pc-windows-gnu",
+        "manual",
+    ],
+    version = "0.4.0",
+    # buildifier: leave-alone
+    deps = [
+        ":winapi_i686_pc_windows_gnu_build_script",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.winapi-util-0.1.5.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "winapi_util",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=winapi-util",
+        "manual",
+    ],
+    version = "0.1.5",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -1,0 +1,84 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "winapi_x86_64_pc_windows_gnu_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "winapi_x86_64_pc_windows_gnu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=winapi-x86_64-pc-windows-gnu",
+        "manual",
+    ],
+    version = "0.4.0",
+    # buildifier: leave-alone
+    deps = [
+        ":winapi_x86_64_pc_windows_gnu_build_script",
+    ],
+)

--- a/third_party/rust/crates/remote/BUILD.yaml-rust-0.4.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.yaml-rust-0.4.5.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust/crates", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "dump_yaml" with type "example" omitted
+
+rust_library(
+    name = "yaml_rust",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=yaml-rust",
+        "manual",
+    ],
+    version = "0.4.5",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__linked_hash_map__0_5_6//:linked_hash_map",
+    ],
+)
+
+# Unsupported target "quickcheck" with type "test" omitted
+
+# Unsupported target "spec_test" with type "test" omitted
+
+# Unsupported target "test_round_trip" with type "test" omitted

--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -1,0 +1,12 @@
+load("@rules_rust//rust:repositories.bzl", "rust_repositories")
+load("//third_party/rust/crates:crates.bzl", "raze_fetch_remote_crates")
+
+def fetch_remote_crates():
+    raze_fetch_remote_crates()
+
+def rust_deps():
+    rust_repositories(
+        edition = "2021",
+        version = "1.60.0",
+    )
+    fetch_remote_crates()

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -1,0 +1,11 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def rust_repos():
+    http_archive(
+        name = "rules_rust",
+        sha256 = "0cc7e6b39e492710b819e00d48f2210ae626b717a3ab96e048c43ab57e61d204",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.10.0/rules_rust-v0.10.0.tar.gz",
+            "https://github.com/bazelbuild/rules_rust/releases/download/0.10.0/rules_rust-v0.10.0.tar.gz",
+        ],
+    )


### PR DESCRIPTION
Because `serde_annotate` is not yet published on `crates.io` _and_ because I have no immediate plans to do so (project is still in too much flux), adding bazel support directly to the project is the most expedient course of action for integrating into OpenTitan.

This is because:
- Without publising in a registry, `cargo raze` only wants to use `git` URLs which are incompatible with OpenTitan's air gapped build configuration.
- By tagging or releasing on github, we create stable https URLs of source-code archives that can be downloaded and verified by OpenTitan's bazel workspace.

Furthermore, by avoiding cargo-raze for this project, we have more flexible options for dealing with development branches of serde-annotate within OpenTitan.

Note: serde-annotate uses `cargo raze` _itself_ to satisfy its own dependencies.
