### PR TITLE
Fix serializing Option and NewType structs

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-09-21"

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -186,7 +186,7 @@ impl<'s, 'a> ser::Serializer for &'s mut AnnotatedSerializer<'a> {
     where
         T: ?Sized + ser::Serialize,
     {
-        value.serialize(self)
+        self.serialize(value, None)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
@@ -214,7 +214,13 @@ impl<'s, 'a> ser::Serializer for &'s mut AnnotatedSerializer<'a> {
     where
         T: ?Sized + ser::Serialize,
     {
-        value.serialize(self)
+        let field = MemberId::Index(0);
+        let node = self.serialize(value, self.annotate(None, &field))?;
+        if let Some(c) = self.comment(None, &field) {
+            Ok(Document::Fragment(vec![c, node]))
+        } else {
+            Ok(node)
+        }
     }
 
     fn serialize_newtype_variant<T>(

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -265,11 +265,15 @@ enum NesAddress {
     Chr(#[annotate(format=hex)] u8, #[annotate(format=hex)] u16),
 }
 
+#[derive(Serialize, Deserialize, Annotate, Debug, PartialEq)]
+struct CpuAddress(#[annotate(format=hex)] u16);
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct Addresses {
     a: NesAddress,
     b: NesAddress,
-    c: NesAddress,
+    c: Option<NesAddress>,
+    d: CpuAddress,
 }
 
 #[test]
@@ -277,7 +281,8 @@ fn test_nes_addresses() -> Result<()> {
     let value = Addresses {
         a: NesAddress::File(0x4010),
         b: NesAddress::Prg(1, 0x8000),
-        c: NesAddress::Chr(2, 0x400),
+        c: Some(NesAddress::Chr(2, 0x400)),
+        d: CpuAddress(0xFFFA),
     };
 
     tester!(
@@ -294,7 +299,8 @@ fn test_nes_addresses() -> Result<()> {
           },
           "c": {
             "Chr": [2, 1024]
-          }
+          },
+          "d": 65530
         }"#
     );
 
@@ -315,7 +321,8 @@ fn test_nes_addresses() -> Result<()> {
           c: {
             // NES CHR bank:address
             Chr: [0x2, 0x400]
-          }
+          },
+          d: 0xFFFA
         }"#
     );
 
@@ -333,7 +340,8 @@ fn test_nes_addresses() -> Result<()> {
             Prg: [0x1, 0x8000]
           c:
             # NES CHR bank:address
-            Chr: [0x2, 0x400]"#
+            Chr: [0x2, 0x400]
+          d: 0xFFFA"#
     );
 
     Ok(())


### PR DESCRIPTION
The serializer was not providing annotations for Option<T> or newtype
structs.

Signed-off-by: Chris Frantz <cfrantz@google.com>