### PR TITLE
Expose the integer::Base enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use de::{from_str, Deserialize, Deserializer};
 pub use doc_iter::DocPath;
 pub use document::{BytesFormat, CommentFormat, Document, StrFormat};
 pub use error::Error;
-pub use integer::{Int, IntValue};
+pub use integer::{Base, Int, IntValue};
 pub use json::Json;
 pub use ser::{serialize, AnnotatedSerializer};
 pub use yaml::Yaml;


### PR DESCRIPTION
The `integer::Base` enum needs to be public so the allowed bases can be set during serialization.