### PR TITLE
Use patched version of rules_rust to support airgapped envs.

### DIFF
--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -3,9 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def rust_repos():
     http_archive(
         name = "rules_rust",
-        sha256 = "0cc7e6b39e492710b819e00d48f2210ae626b717a3ab96e048c43ab57e61d204",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.10.0/rules_rust-v0.10.0.tar.gz",
-            "https://github.com/bazelbuild/rules_rust/releases/download/0.10.0/rules_rust-v0.10.0.tar.gz",
-        ],
+        sha256 = "fe8d7e62d093e10d8f87b9fd26e4ee2b8d64667ab6827f41fb38eda640233e0f",
+        strip_prefix = "rules_rust-add-missing-rv32-shas-20221031_01",
+        url = "https://github.com/lowRISC/rules_rust/archive/refs/tags/add-missing-rv32-shas-20221031_01.tar.gz",
     )


### PR DESCRIPTION
Signed-off-by: Timothy Trippel <ttrippel@google.com>