### PR TITLE
Add specialization for reference-to-type

### DIFF
--- a/annotate_derive/src/expand.rs
+++ b/annotate_derive/src/expand.rs
@@ -140,6 +140,7 @@ fn impl_struct(input: Struct) -> TokenStream {
                 // We don't have to implement `thunk_serialize` because the default implementation
                 // already does what we need.
             }
+            serde_annotate::annotate_ref!(#name);
         };
     }
 }
@@ -171,6 +172,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                 // We don't have to implement `thunk_serialize` because the default implementation
                 // already does what we need.
             }
+            serde_annotate::annotate_ref!(#name);
         };
     }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -210,29 +210,15 @@ impl JsonEmitter {
             Document::Null => self.emit_null(w),
             Document::Compact(d) => self.emit_compact(w, d),
             Document::Fragment(ds) => {
-                match &ds[..] {
-                    // Currently, an enum unit-variant is the only place in the serializer where a
-                    // Fragment is constructed placing the comment after the node.  For this case,
-                    // we want to emit the variant name followed by the comment on the same line.
-                    [n, Document::Comment(c, f)] => {
-                        self.emit_node(w, n)?;
-                        if !self.compact && !self.comment.is_empty() {
-                            write!(w, " ")?;
-                            self.emit_comment(w, c, f)?;
-                        }
+                let mut prior_val = false;
+                for d in ds {
+                    if prior_val {
+                        self.writeln(w, "")?;
+                        self.emit_indent(w)?;
                     }
-                    _ => {
-                        let mut prior_val = false;
-                        for d in ds {
-                            if prior_val {
-                                self.writeln(w, "")?;
-                                self.emit_indent(w)?;
-                            }
-                            self.emit_node(w, d)?;
-                            prior_val = d.has_value();
-                        }
-                    }
-                };
+                    self.emit_node(w, d)?;
+                    prior_val = d.has_value();
+                }
                 Ok(())
             }
         }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -204,11 +204,15 @@ impl<'s, 'a> ser::Serializer for &'s mut AnnotatedSerializer<'a> {
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
         let node = self.serialize_str(variant)?;
-        if let Some(c) = self.comment(Some(variant), &MemberId::Variant) {
-            Ok(Document::Fragment(vec![node, c]))
-        } else {
-            Ok(node)
-        }
+        // TODO(serde-annotate#6): currently, placing a comment on a unit variant results in
+        // ugly (json) or bad (yaml) documents.  For now, omit comments on
+        // unit variants until we refactor comment emitting.
+        //if let Some(c) = self.comment(Some(variant), &MemberId::Variant) {
+        //    Ok(Document::Fragment(vec![c, node]))
+        //} else {
+        //    Ok(node)
+        //}
+        Ok(node)
     }
 
     fn serialize_newtype_struct<T>(
@@ -221,11 +225,15 @@ impl<'s, 'a> ser::Serializer for &'s mut AnnotatedSerializer<'a> {
     {
         let field = MemberId::Index(0);
         let node = self.serialize(value, self.annotate(None, &field))?;
-        if let Some(c) = self.comment(None, &field) {
-            Ok(Document::Fragment(vec![c, node]))
-        } else {
-            Ok(node)
-        }
+        // TODO(serde-annotate#6): currently, placing a comment on a newtype structs results in
+        // ugly (json) or bad (yaml) documents.  For now, omit comments on
+        // unit variants until we refactor comment emitting.
+        //if let Some(c) = self.comment(None, &field) {
+        //    Ok(Document::Fragment(vec![c, node]))
+        //} else {
+        //    Ok(node)
+        //}
+        Ok(node)
     }
 
     fn serialize_newtype_variant<T>(

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -97,26 +97,15 @@ impl YamlEmitter {
             Document::Null => self.emit_null(w),
             Document::Compact(d) => self.emit_compact(w, d),
             Document::Fragment(ds) => {
-                match &ds[..] {
-                    [n, Document::Comment(c, f)] => {
-                        self.emit_node(w, n)?;
-                        if !self.compact {
-                            write!(w, " ")?;
-                            self.emit_comment(w, c, f)?;
-                        }
+                let mut prior_val = false;
+                for d in ds {
+                    if prior_val {
+                        self.writeln(w, "")?;
+                        self.emit_indent(w)?;
                     }
-                    _ => {
-                        let mut prior_val = false;
-                        for d in ds {
-                            if prior_val {
-                                self.writeln(w, "")?;
-                                self.emit_indent(w)?;
-                            }
-                            self.emit_node(w, d)?;
-                            prior_val = d.has_value();
-                        }
-                    }
-                };
+                    self.emit_node(w, d)?;
+                    prior_val = d.has_value();
+                }
                 Ok(())
             }
         }

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -263,12 +263,14 @@ enum NesAddress {
     Prg(#[annotate(format=hex)] u8, #[annotate(format=hex)] u16),
     #[annotate(format=compact, comment="NES CHR bank:address")]
     Chr(#[annotate(format=hex)] u8, #[annotate(format=hex)] u16),
+    // TODO(serde-annotate#6): Currently, we do not emit comments for unit variants.
     #[annotate(comment = "Bad Address")]
     Invalid,
 }
 
+// TODO(serde-annotate#6): Currently, we do not emit comments for newtype structs.
 #[derive(Serialize, Deserialize, Annotate, Debug, PartialEq)]
-struct CpuAddress(#[annotate(format=hex)] u16);
+struct CpuAddress(#[annotate(format=hex, comment="CPU Address")] u16);
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct Addresses {
@@ -339,7 +341,7 @@ fn test_nes_addresses() -> Result<()> {
             0xFFFC,
             0xFFFE
           ],
-          inv: "Invalid" // Bad Address
+          inv: "Invalid"
         }"#
     );
 
@@ -362,7 +364,7 @@ fn test_nes_addresses() -> Result<()> {
             - 0xFFFA
             - 0xFFFC
             - 0xFFFE
-          inv: Invalid # Bad Address"#
+          inv: Invalid"#
     );
 
     Ok(())

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -275,8 +275,11 @@ struct Addresses {
     a: NesAddress,
     b: NesAddress,
     c: Option<NesAddress>,
-    d: CpuAddress,
-    e: NesAddress,
+    // Note: using a vec here causes the serializer to request
+    // serializing &CpuAddress rather than CpuAddress.  This tests
+    // that the specializations of Annotate for &T are working.
+    vectors: Vec<CpuAddress>,
+    inv: NesAddress,
 }
 
 #[test]
@@ -285,8 +288,8 @@ fn test_nes_addresses() -> Result<()> {
         a: NesAddress::File(0x4010),
         b: NesAddress::Prg(1, 0x8000),
         c: Some(NesAddress::Chr(2, 0x400)),
-        d: CpuAddress(0xFFFA),
-        e: NesAddress::Invalid,
+        vectors: vec![CpuAddress(0xFFFA), CpuAddress(0xFFFC), CpuAddress(0xFFFE)],
+        inv: NesAddress::Invalid,
     };
 
     tester!(
@@ -304,8 +307,12 @@ fn test_nes_addresses() -> Result<()> {
           "c": {
             "Chr": [2, 1024]
           },
-          "d": 65530,
-          "e": "Invalid"
+          "vectors": [
+            65530,
+            65532,
+            65534
+          ],
+          "inv": "Invalid"
         }"#
     );
 
@@ -327,8 +334,12 @@ fn test_nes_addresses() -> Result<()> {
             // NES CHR bank:address
             Chr: [0x2, 0x400]
           },
-          d: 0xFFFA,
-          e: "Invalid" // Bad Address
+          vectors: [
+            0xFFFA,
+            0xFFFC,
+            0xFFFE
+          ],
+          inv: "Invalid" // Bad Address
         }"#
     );
 
@@ -347,8 +358,11 @@ fn test_nes_addresses() -> Result<()> {
           c:
             # NES CHR bank:address
             Chr: [0x2, 0x400]
-          d: 0xFFFA
-          e: Invalid # Bad Address"#
+          vectors:
+            - 0xFFFA
+            - 0xFFFC
+            - 0xFFFE
+          inv: Invalid # Bad Address"#
     );
 
     Ok(())


### PR DESCRIPTION
The serde library implements `Serialize` for all `&T where T:
Serialize`.  This causes min_specialization to select the default
implementation of `Annotate` for `&T` when a specialized implementation
exists for `T`.

We supply a forwarding implementation for `&T` to `T` for every type
we derive `Annotate` on.

This is also a bugfix for handling comments on unit variants and newtype structs.