### PR TITLE
Migrate from ansi_term to anstyle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,7 +42,7 @@ rust_library(
     ],
     version = "0.1.0",
     deps = [
-        "@crate_index//:ansi_term",
+        "@crate_index//:anstyle",
         "@crate_index//:num-traits",
         "@crate_index//:once_cell",
         "@crate_index//:pest",

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3cb3e6e5689bc12c789664005b0b8e96f13e4a6ef9f2c8aa80495c6e3021dd2c",
+  "checksum": "5cd297aee7b1618bc3ab52a21b5c9b7b82726e12ac44889b16336186f873aee3",
   "crates": {
     "aho-corasick 1.0.5": {
       "name": "aho-corasick",
@@ -89,47 +89,6 @@
         "version": "0.1.0"
       },
       "license": null
-    },
-    "ansi_term 0.12.1": {
-      "name": "ansi_term",
-      "version": "0.12.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/ansi_term/0.12.1/download",
-          "sha256": "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ansi_term",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "ansi_term",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(target_os = \"windows\")": [
-              {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
-              }
-            ]
-          }
-        },
-        "edition": "2015",
-        "version": "0.12.1"
-      },
-      "license": "MIT"
     },
     "anstream 0.5.0": {
       "name": "anstream",
@@ -2124,8 +2083,8 @@
         "deps": {
           "common": [
             {
-              "id": "ansi_term 0.12.1",
-              "target": "ansi_term"
+              "id": "anstyle 1.0.2",
+              "target": "anstyle"
             },
             {
               "id": "num-traits 0.2.16",
@@ -2944,188 +2903,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "winapi 0.3.9": {
-      "name": "winapi",
-      "version": "0.3.9",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/winapi/0.3.9/download",
-          "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "winapi",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "winapi",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "consoleapi",
-            "errhandlingapi",
-            "fileapi",
-            "handleapi",
-            "processenv"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "winapi 0.3.9",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {
-            "i686-pc-windows-gnu": [
-              {
-                "id": "winapi-i686-pc-windows-gnu 0.4.0",
-                "target": "winapi_i686_pc_windows_gnu"
-              }
-            ],
-            "x86_64-pc-windows-gnu": [
-              {
-                "id": "winapi-x86_64-pc-windows-gnu 0.4.0",
-                "target": "winapi_x86_64_pc_windows_gnu"
-              }
-            ]
-          }
-        },
-        "edition": "2015",
-        "version": "0.3.9"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "winapi-i686-pc-windows-gnu 0.4.0": {
-      "name": "winapi-i686-pc-windows-gnu",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
-          "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "winapi_i686_pc_windows_gnu",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "winapi_i686_pc_windows_gnu",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "winapi-i686-pc-windows-gnu 0.4.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.4.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT/Apache-2.0"
-    },
-    "winapi-x86_64-pc-windows-gnu 0.4.0": {
-      "name": "winapi-x86_64-pc-windows-gnu",
-      "version": "0.4.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
-          "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "winapi_x86_64_pc_windows_gnu",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "winapi_x86_64_pc_windows_gnu",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "winapi-x86_64-pc-windows-gnu 0.4.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.4.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "windows-sys 0.48.0": {
       "name": "windows-sys",
       "version": "0.48.0",
@@ -3718,18 +3495,11 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-none"
     ],
-    "cfg(target_os = \"windows\")": [
-      "aarch64-pc-windows-msvc",
-      "i686-pc-windows-msvc",
-      "x86_64-pc-windows-msvc"
-    ],
     "cfg(windows)": [
       "aarch64-pc-windows-msvc",
       "i686-pc-windows-msvc",
       "x86_64-pc-windows-msvc"
     ],
-    "i686-pc-windows-gnu": [],
-    "x86_64-pc-windows-gnu": [],
     "x86_64-pc-windows-gnullvm": []
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,15 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,7 +373,7 @@ name = "serde_annotate"
 version = "0.1.0"
 dependencies = [
  "annotate_derive",
- "ansi_term",
+ "anstyle",
  "anyhow",
  "clap",
  "deser-hjson",
@@ -531,28 +522,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ansi_term = "0.12"
+anstyle = "1.0"
 thiserror = "1.0"
 num-traits = "0.2.15"
 serde = "1.0"

--- a/examples/autoschema.rs
+++ b/examples/autoschema.rs
@@ -7,7 +7,7 @@
 ///
 /// IOW, this program helps you do what you should have done when you thought
 /// "Who cares? Its just JSON! It's schema free!".
-use ansi_term::{Color, Style};
+use anstyle::{AnsiColor, Style};
 use anyhow::Result;
 use clap::Parser;
 use serde_annotate::{DocPath, Document, Int};
@@ -23,8 +23,8 @@ struct ColorProfile {
 impl ColorProfile {
     pub fn basic() -> Self {
         ColorProfile {
-            error: Style::new().fg(Color::Red),
-            ok: Style::new().fg(Color::Green),
+            error: AnsiColor::Red.on_default(),
+            ok: AnsiColor::Green.on_default(),
         }
     }
 }
@@ -100,15 +100,7 @@ impl Schema {
             || self.total == self.object
             || self.total == self.array;
 
-        print!(
-            "{}",
-            (if good {
-                color.ok.prefix()
-            } else {
-                color.error.prefix()
-            })
-            .to_string()
-        );
+        print!("{}", (if good { color.ok } else { color.error }).render());
         print!("{0:>1$}|{2:->20}: ", "", indent * 4, name,);
         print!(
             "(n:{:<3} b:{:<3} s:{:<3} i:{:<3} f:{:<3} o:{:<3} a:{:<3}) / {:<3}",
@@ -121,7 +113,7 @@ impl Schema {
             self.array,
             self.total,
         );
-        println!("{}", color.ok.suffix().to_string());
+        println!("{}", color.ok.render_reset());
         for (k, v) in self.children.iter() {
             v.print(k.as_str(), indent + 1, color)
         }

--- a/examples/autoschema.rs
+++ b/examples/autoschema.rs
@@ -75,7 +75,7 @@ impl Schema {
 
     fn detect(&mut self, root: &Document) {
         for (path, doc) in root.iter_path() {
-            let mut node = self.get_mut(&path);
+            let node = self.get_mut(&path);
             node.total += 1;
             match doc {
                 Document::Null => node.null += 1,

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,6 @@
-use ansi_term::{Color, Style};
+use std::fmt::Display;
+
+use anstyle::{AnsiColor, Style};
 
 /// A `ColorProfile` describes how to apply color information when rendering a document.
 #[derive(Default, Clone, Copy)]
@@ -29,16 +31,43 @@ impl ColorProfile {
     /// Returns a basic color profile.
     pub fn basic() -> Self {
         ColorProfile {
-            aggregate: Style::new().fg(Color::Red),
+            aggregate: AnsiColor::Red.on_default(),
             punctuation: Style::new(),
-            comment: Style::new().fg(Color::White).italic(),
-            null: Style::new().fg(Color::Red).bold(),
-            key: Style::new().fg(Color::Cyan),
-            string: Style::new().fg(Color::Green),
-            escape: Style::new().fg(Color::Green).bold(),
-            boolean: Style::new().fg(Color::Blue),
-            integer: Style::new().fg(Color::Blue).bold(),
-            float: Style::new().fg(Color::Purple),
+            comment: AnsiColor::White.on_default().italic(),
+            null: AnsiColor::Red.on_default().bold(),
+            key: AnsiColor::Cyan.on_default(),
+            string: AnsiColor::Green.on_default(),
+            escape: AnsiColor::Green.on_default().bold(),
+            boolean: AnsiColor::Blue.on_default(),
+            integer: AnsiColor::Blue.on_default().bold(),
+            float: AnsiColor::Magenta.on_default(),
         }
+    }
+}
+
+pub(crate) struct Paint<T> {
+    style: Style,
+    text: T,
+}
+
+impl<T: Display> std::fmt::Display for Paint<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{}{}",
+            self.style.render(),
+            self.text,
+            self.style.render_reset()
+        )
+    }
+}
+
+pub(crate) trait PaintExt {
+    fn paint<T>(self, text: T) -> Paint<T>;
+}
+
+impl PaintExt for Style {
+    fn paint<T>(self, text: T) -> Paint<T> {
+        Paint { style: self, text }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,13 +17,13 @@ pub enum Error {
     #[error("unhandled escape: `\\{0}`")]
     EscapeError(char),
     #[error("formatter error: {0:?}")]
-    FmtError(std::fmt::Error),
+    FmtError(#[from] std::fmt::Error),
     #[error("Hexdump error: {0}")]
     HexdumpError(String),
     #[error("Type {0:?} is not valid as a mapping key")]
     KeyTypeError(&'static str),
     #[error(transparent)]
-    ParseError(#[from] ParseError),
+    ParseError(Box<ParseError>),
     #[error(transparent)]
     ParseBoolError(#[from] ParseBoolError),
     #[error(transparent)]
@@ -48,8 +48,8 @@ impl de::Error for Error {
     }
 }
 
-impl From<std::fmt::Error> for Error {
-    fn from(e: std::fmt::Error) -> Self {
-        Error::FmtError(e)
+impl From<ParseError> for Error {
+    fn from(e: ParseError) -> Self {
+        Error::ParseError(Box::new(e))
     }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,4 +1,4 @@
-use crate::color::ColorProfile;
+use crate::color::{ColorProfile, PaintExt};
 use crate::document::{CommentFormat, Document, StrFormat};
 use crate::error::Error;
 use crate::integer::{Base, Int};

--- a/src/json.rs
+++ b/src/json.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::integer::{Base, Int};
 use once_cell::sync::OnceCell;
 use std::collections::HashSet;
-use std::fmt;
+use std::fmt::{self, Display};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -238,7 +238,11 @@ impl JsonEmitter {
         self.emit_indent(w)?;
         for (i, value) in bytes.iter().enumerate() {
             if i > 0 {
-                self.writeln(w, ",")?;
+                if self.compact {
+                    write!(w, "{}", self.color.punctuation.paint(", "))?;
+                } else {
+                    writeln!(w, "{}", self.color.punctuation.paint(","))?;
+                }
                 self.emit_indent(w)?;
             }
             write!(w, "{}", value)?;
@@ -618,17 +622,11 @@ impl JsonEmitter {
         Ok(())
     }
 
-    fn writeln<W: fmt::Write>(&mut self, w: &mut W, s: &str) -> Result<()> {
+    fn writeln<W: fmt::Write>(&mut self, w: &mut W, s: impl Display) -> Result<()> {
         if self.compact {
-            match s {
-                "," => write!(w, "{} ", self.color.punctuation.paint(","))?,
-                _ => write!(w, "{}", s)?,
-            };
+            write!(w, "{}", s)?;
         } else {
-            match s {
-                "," => writeln!(w, "{}", self.color.punctuation.paint(","))?,
-                _ => writeln!(w, "{}", s)?,
-            };
+            writeln!(w, "{}", s)?;
         }
         Ok(())
     }

--- a/src/json.rs
+++ b/src/json.rs
@@ -234,7 +234,7 @@ impl JsonEmitter {
 
     fn emit_bytes<W: fmt::Write>(&mut self, w: &mut W, bytes: &[u8]) -> Result<()> {
         self.level += 1;
-        self.writeln(w, &self.color.aggregate.paint("[").to_string())?;
+        self.writeln(w, self.color.aggregate.paint("["))?;
         self.emit_indent(w)?;
         for (i, value) in bytes.iter().enumerate() {
             if i > 0 {
@@ -250,14 +250,14 @@ impl JsonEmitter {
         self.writeln(w, "")?;
         self.level -= 1;
         self.emit_indent(w)?;
-        write!(w, "{}", &self.color.aggregate.paint("]"))?;
+        write!(w, "{}", self.color.aggregate.paint("]"))?;
         Ok(())
     }
 
     // TODO: Can this function be rewritten to be less complex?
     fn emit_sequence<W: fmt::Write>(&mut self, w: &mut W, sequence: &[Document]) -> Result<()> {
         self.level += 1;
-        self.writeln(w, &self.color.aggregate.paint("[").to_string())?;
+        self.writeln(w, self.color.aggregate.paint("["))?;
         if !sequence.is_empty() {
             self.emit_indent(w)?;
         }
@@ -289,7 +289,7 @@ impl JsonEmitter {
                     if !val_done {
                         self.emit_node(w, node)?;
                         if i != last {
-                            write!(w, "{}", &self.color.punctuation.paint(","))?;
+                            write!(w, "{}", self.color.punctuation.paint(","))?;
                         }
                         val_done = true;
                         need_eol = true;
@@ -300,7 +300,7 @@ impl JsonEmitter {
             } else {
                 self.emit_node(w, value)?;
                 if i != last {
-                    write!(w, "{}", &self.color.punctuation.paint(","))?;
+                    write!(w, "{}", self.color.punctuation.paint(","))?;
                 }
                 need_eol = true;
             }
@@ -310,7 +310,7 @@ impl JsonEmitter {
         }
         self.level -= 1;
         self.emit_indent(w)?;
-        write!(w, "{}", &self.color.aggregate.paint("]"))?;
+        write!(w, "{}", self.color.aggregate.paint("]"))?;
         Ok(())
     }
 
@@ -332,7 +332,7 @@ impl JsonEmitter {
     // TODO: Can this function be rewritten to be less complex?
     fn emit_mapping<W: fmt::Write>(&mut self, w: &mut W, mapping: &[Document]) -> Result<()> {
         self.level += 1;
-        self.writeln(w, &self.color.aggregate.paint("{").to_string())?;
+        self.writeln(w, self.color.aggregate.paint("{"))?;
         if !mapping.is_empty() {
             self.emit_indent(w)?;
         }
@@ -370,21 +370,21 @@ impl JsonEmitter {
                             w,
                             "{}{}{}",
                             self.color.punctuation.paint("\""),
-                            self.color.key.paint(format!("{}", v)),
+                            self.color.key.paint(v),
                             self.color.punctuation.paint("\"")
                         )?,
                         Document::Int(v) => write!(
                             w,
                             "{}{}{}",
                             self.color.punctuation.paint("\""),
-                            self.color.key.paint(format!("{}", v)),
+                            self.color.key.paint(v),
                             self.color.punctuation.paint("\"")
                         )?,
                         Document::Float(v) => write!(
                             w,
                             "{}{}{}",
                             self.color.punctuation.paint("\""),
-                            self.color.key.paint(format!("{}", v)),
+                            self.color.key.paint(v),
                             self.color.punctuation.paint("\"")
                         )?,
                         Document::Comment(_, _) => return Err(Error::KeyTypeError("comment")),
@@ -395,12 +395,12 @@ impl JsonEmitter {
                         Document::Fragment(_) => return Err(Error::KeyTypeError("fragment")),
                         Document::Null => return Err(Error::KeyTypeError("null")),
                     };
-                    write!(w, "{}", &self.color.punctuation.paint(": "))?;
+                    write!(w, "{}", self.color.punctuation.paint(": "))?;
                     key_done = true;
                 } else if !val_done {
                     self.emit_node(w, node)?;
                     if i != last {
-                        write!(w, "{}", &self.color.punctuation.paint(","))?;
+                        write!(w, "{}", self.color.punctuation.paint(","))?;
                     }
                     val_done = true;
                     need_eol = true;
@@ -412,7 +412,7 @@ impl JsonEmitter {
         }
         self.level -= 1;
         self.emit_indent(w)?;
-        write!(w, "{}", &self.color.aggregate.paint("}"))?;
+        write!(w, "{}", self.color.aggregate.paint("}"))?;
         Ok(())
     }
 
@@ -459,7 +459,9 @@ impl JsonEmitter {
                 write!(
                     w,
                     "{}",
-                    self.color.comment.paint(format!("{} {}", leader, line))
+                    self.color
+                        .comment
+                        .paint(format_args!("{} {}", leader, line))
                 )?;
             }
         }
@@ -479,7 +481,7 @@ impl JsonEmitter {
     }
 
     fn emit_string_strict<W: fmt::Write>(&mut self, w: &mut W, value: &str) -> Result<()> {
-        write!(w, "{}", &self.color.punctuation.paint("\""))?;
+        write!(w, "{}", self.color.punctuation.paint("\""))?;
         let bytes = value.as_bytes();
         let mut start = 0;
         for (i, &byte) in bytes.iter().enumerate() {
@@ -488,26 +490,28 @@ impl JsonEmitter {
                 continue;
             }
             if start < i {
-                write!(w, "{}", &self.color.string.paint(&value[start..i]))?;
+                write!(w, "{}", self.color.string.paint(&value[start..i]))?;
             }
             match escape {
                 UU => write!(
                     w,
                     "{}",
-                    &self.color.escape.paint(format!("\\u{:04x}", byte))
+                    self.color.escape.paint(format_args!("\\u{:04x}", byte))
                 )?,
                 _ => write!(
                     w,
                     "{}",
-                    &self.color.escape.paint(format!("\\{}", escape as char))
+                    self.color
+                        .escape
+                        .paint(format_args!("\\{}", escape as char))
                 )?,
             };
             start = i + 1;
         }
         if start != bytes.len() {
-            write!(w, "{}", &self.color.string.paint(&value[start..]))?;
+            write!(w, "{}", self.color.string.paint(&value[start..]))?;
         }
-        write!(w, "{}", &self.color.punctuation.paint("\""))?;
+        write!(w, "{}", self.color.punctuation.paint("\""))?;
         Ok(())
     }
 
@@ -516,10 +520,10 @@ impl JsonEmitter {
             writeln!(w)?;
             self.level += 1;
             self.emit_indent(w)?;
-            self.writeln(w, &self.color.punctuation.paint("'''").to_string())?;
+            self.writeln(w, self.color.punctuation.paint("'''"))?;
             self.emit_indent(w)?;
         } else {
-            write!(w, "{}", &self.color.punctuation.paint("\""))?;
+            write!(w, "{}", self.color.punctuation.paint("\""))?;
         }
         let bytes = value.as_bytes();
         let mut start = 0;
@@ -529,19 +533,21 @@ impl JsonEmitter {
                 continue;
             }
             if start < i {
-                write!(w, "{}", &self.color.string.paint(&value[start..i]))?;
+                write!(w, "{}", self.color.string.paint(&value[start..i]))?;
             }
             match escape {
                 UU => write!(
                     w,
                     "{}",
-                    &self.color.escape.paint(format!("\\u{:04x}", byte))
+                    self.color.escape.paint(format_args!("\\u{:04x}", byte))
                 )?,
                 NN => match self.multiline {
                     Multiline::None => write!(
                         w,
                         "{}",
-                        &self.color.escape.paint(format!("\\{}", escape as char))
+                        self.color
+                            .escape
+                            .paint(format_args!("\\{}", escape as char))
                     )?,
                     Multiline::Json5 => writeln!(w, "{}", self.color.escape.paint("\\"))?,
                     Multiline::Hjson => {
@@ -552,30 +558,32 @@ impl JsonEmitter {
                 _ => write!(
                     w,
                     "{}",
-                    &self.color.escape.paint(format!("\\{}", escape as char))
+                    self.color
+                        .escape
+                        .paint(format_args!("\\{}", escape as char))
                 )?,
             };
             start = i + 1;
         }
         if start != bytes.len() {
-            write!(w, "{}", &self.color.string.paint(&value[start..]))?;
+            write!(w, "{}", self.color.string.paint(&value[start..]))?;
         }
         if self.multiline == Multiline::Hjson {
             writeln!(w)?;
             self.emit_indent(w)?;
-            write!(w, "{}", &self.color.punctuation.paint("'''"))?;
+            write!(w, "{}", self.color.punctuation.paint("'''"))?;
             self.level -= 1;
         } else {
-            write!(w, "{}", &self.color.punctuation.paint("\""))?;
+            write!(w, "{}", self.color.punctuation.paint("\""))?;
         }
         Ok(())
     }
 
     fn emit_boolean<W: fmt::Write>(&mut self, w: &mut W, b: bool) -> Result<()> {
         if b {
-            write!(w, "{}", &self.color.boolean.paint("true"))?;
+            write!(w, "{}", self.color.boolean.paint("true"))?;
         } else {
-            write!(w, "{}", &self.color.boolean.paint("false"))?;
+            write!(w, "{}", self.color.boolean.paint("false"))?;
         }
         Ok(())
     }
@@ -594,18 +602,18 @@ impl JsonEmitter {
                 self.color.punctuation.paint("\"")
             )?;
         } else {
-            write!(w, "{}", &self.color.integer.paint(s))?;
+            write!(w, "{}", self.color.integer.paint(s))?;
         }
         Ok(())
     }
 
     fn emit_float<W: fmt::Write>(&mut self, w: &mut W, f: f64) -> Result<()> {
-        write!(w, "{}", &self.color.float.paint(format!("{}", f)))?;
+        write!(w, "{}", self.color.float.paint(f))?;
         Ok(())
     }
 
     fn emit_null<W: fmt::Write>(&mut self, w: &mut W) -> Result<()> {
-        write!(w, "{}", &self.color.null.paint("null"))?;
+        write!(w, "{}", self.color.null.paint("null"))?;
         Ok(())
     }
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -1,4 +1,4 @@
-use crate::color::ColorProfile;
+use crate::color::{ColorProfile, PaintExt};
 use crate::document::{CommentFormat, Document, StrFormat};
 use crate::error::Error;
 use crate::integer::Int;

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -2,7 +2,7 @@ use crate::color::{ColorProfile, PaintExt};
 use crate::document::{CommentFormat, Document, StrFormat};
 use crate::error::Error;
 use crate::integer::Int;
-use std::fmt;
+use std::fmt::{self, Display};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -416,17 +416,11 @@ impl YamlEmitter {
         Ok(())
     }
 
-    fn writeln<W: fmt::Write>(&mut self, w: &mut W, s: &str) -> Result<()> {
+    fn writeln<W: fmt::Write>(&mut self, w: &mut W, s: impl Display) -> Result<()> {
         if self.compact {
-            match s {
-                "," => write!(w, "{}", self.color.punctuation.paint(", "))?,
-                _ => write!(w, "{}", s)?,
-            };
+            write!(w, "{}", s)?;
         } else {
-            match s {
-                "," => writeln!(w, "{}", self.color.punctuation.paint(","))?,
-                _ => writeln!(w, "{}", s)?,
-            };
+            writeln!(w, "{}", s)?;
         }
         Ok(())
     }


### PR DESCRIPTION
ansi_term is unmaintained. In a range of possible alternatives, anstyle was chosen because it's a dependency of clap already.